### PR TITLE
Split `Device` into separate `xarxa-driver` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ license = "0BSD"
 # ensure that the correct features are enabled.
 autoexamples = false
 
+[workspace]
+members = ["xarxa-driver"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [dependencies]
+xarxa-driver = { version = "0.1.0", path = "xarxa-driver" }
 managed = { version = "0.8", default-features = false, features = ["map"] }
 byteorder = { version = "1.0", default-features = false }
 log = { version = "0.4.4", default-features = false, optional = true }
@@ -42,7 +46,7 @@ idna = { version = "=1.0.1" }
 std = ["managed/std", "alloc"]
 alloc = ["managed/alloc", "defmt?/alloc"]
 verbose = []
-defmt = ["dep:defmt", "heapless/defmt"]
+defmt = ["dep:defmt", "heapless/defmt", "xarxa-driver/defmt"]
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]
@@ -93,8 +97,8 @@ defmt = ["dep:defmt", "heapless/defmt"]
 # Enable Reno TCP congestion control algorithm, and it is used as a default congestion controller.
 "socket-tcp-reno" = []
 
-"packetmeta-id" = []
-"packetmeta-timestamp" = []
+"packetmeta-id" = ["xarxa-driver/packetmeta-id"]
+"packetmeta-timestamp" = ["xarxa-driver/packetmeta-timestamp"]
 
 "async" = []
 

--- a/ci.sh
+++ b/ci.sh
@@ -70,6 +70,10 @@ check() {
 
     cargo +$version check --examples
 
+    # The driver crate is versioned separately, check it on its own.
+    cargo +$version check -p xarxa-driver
+    cargo +$version check -p xarxa-driver --features defmt,packetmeta-id,packetmeta-timestamp
+
     if [[ $version == "nightly" ]]; then
         cargo +$version check --benches
     fi
@@ -78,7 +82,7 @@ check() {
 clippy() {
     rustup toolchain install $MSRV
     rustup component add clippy --toolchain=$MSRV
-    cargo +$MSRV clippy --tests --examples -- -D warnings
+    cargo +$MSRV clippy --workspace --tests --examples -- -D warnings
 }
 
 build_16bit() {

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, wait as phy_wait};
 use xarxa::socket::tcp;
 use xarxa::time::{Duration, Instant};
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr};
@@ -87,11 +87,11 @@ fn main() {
     let tcp2_socket = tcp::Socket::new(tcp2_rx_buffer, tcp2_tx_buffer);
 
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,7 @@ use std::os::unix::io::AsRawFd;
 use std::str::{self, FromStr};
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, wait as phy_wait};
 use xarxa::socket::tcp;
 use xarxa::time::Instant;
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address};
@@ -30,11 +30,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -9,7 +9,7 @@ use xarxa::socket::dhcpv4;
 use xarxa::time::Instant;
 use xarxa::wire::{EthernetAddress, IpCidr, Ipv4Cidr};
 use xarxa::{
-    phy::{Device, Medium, wait as phy_wait},
+    phy::{Device, DriverMedium, wait as phy_wait},
     time::Duration,
 };
 
@@ -29,11 +29,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
     let mut iface = Interface::new(config, &mut device, Instant::now());

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -3,7 +3,7 @@ mod utils;
 use std::os::unix::io::AsRawFd;
 use xarxa::iface::{Config, Interface, SocketSet};
 use xarxa::phy::Device;
-use xarxa::phy::{Medium, wait as phy_wait};
+use xarxa::phy::{DriverMedium, wait as phy_wait};
 use xarxa::socket::dns::{self, GetQueryResultError};
 use xarxa::time::Instant;
 use xarxa::wire::{DnsQueryType, EthernetAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address};
@@ -25,11 +25,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -6,7 +6,7 @@ use std::str::{self, FromStr};
 use url::Url;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, wait as phy_wait};
 use xarxa::socket::tcp;
 use xarxa::time::Instant;
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address};
@@ -30,11 +30,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -9,7 +9,7 @@ use core::str;
 use log::{debug, error, info};
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Loopback, Medium};
+use xarxa::phy::{Device, DriverMedium, Loopback};
 use xarxa::socket::tcp;
 use xarxa::time::{Duration, Instant};
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr};
@@ -65,7 +65,7 @@ mod mock {
 
 fn main() {
     let clock = mock::Clock::new();
-    let device = Loopback::new(Medium::Ethernet);
+    let device = Loopback::new(DriverMedium::Ethernet);
 
     #[cfg(feature = "std")]
     let mut device = {
@@ -81,11 +81,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
 
     let mut iface = Interface::new(config, &mut device, Instant::now());

--- a/examples/loopback_benchmark.rs
+++ b/examples/loopback_benchmark.rs
@@ -3,13 +3,13 @@ mod utils;
 use log::debug;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Loopback, Medium};
+use xarxa::phy::{Device, DriverMedium, Loopback};
 use xarxa::socket::tcp;
 use xarxa::time::Instant;
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr};
 
 fn main() {
-    let device = Loopback::new(Medium::Ethernet);
+    let device = Loopback::new(DriverMedium::Ethernet);
 
     let mut device = {
         utils::setup_logging("info");
@@ -23,11 +23,11 @@ fn main() {
 
     // Create interface
     let config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
 
     let mut iface = Interface::new(config, &mut device, Instant::now());

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -3,7 +3,7 @@ mod utils;
 use std::os::unix::io::AsRawFd;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, wait as phy_wait};
 use xarxa::socket::{raw, udp};
 use xarxa::time::Instant;
 use xarxa::wire::{
@@ -29,11 +29,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/multicast6.rs
+++ b/examples/multicast6.rs
@@ -4,7 +4,7 @@ use std::os::unix::io::AsRawFd;
 
 use xarxa::iface::{Config, Interface, SocketSet};
 use xarxa::phy::wait as phy_wait;
-use xarxa::phy::{Device, Medium};
+use xarxa::phy::{Device, DriverMedium};
 use xarxa::socket::udp;
 use xarxa::time::Instant;
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr, Ipv6Address};
@@ -39,9 +39,9 @@ fn main() {
     // Create interface
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => Config::new(ethernet_addr.into()),
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ethernet => Config::new(ethernet_addr.into()),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -16,7 +16,7 @@ use xarxa::wire::{
     Ipv4Address, Ipv6Address,
 };
 use xarxa::{
-    phy::Medium,
+    phy::DriverMedium,
     time::{Duration, Instant},
 };
 
@@ -106,11 +106,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 use std::os::unix::io::AsRawFd;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, wait as phy_wait};
 use xarxa::socket::{tcp, udp};
 use xarxa::time::{Duration, Instant};
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address};
@@ -25,11 +25,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
 
     config.random_seed = rand::random();

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -47,7 +47,7 @@ use std::os::unix::io::AsRawFd;
 use std::str;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, RawSocket, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, RawSocket, wait as phy_wait};
 use xarxa::socket::tcp;
 use xarxa::socket::udp;
 use xarxa::time::Instant;
@@ -61,20 +61,21 @@ fn main() {
 
     let mut matches = utils::parse_options(&opts, free);
 
-    let device = RawSocket::new("wpan1", Medium::Ieee802154).unwrap();
+    let device = RawSocket::new("wpan1", DriverMedium::Ieee802154).unwrap();
     let fd = device.as_raw_fd();
     let mut device =
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => Config::new(
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        DriverMedium::Ieee802154 => Config::new(
             Ieee802154Address::Extended([0x1a, 0x0b, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42]).into(),
         ),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
     config.pan_id = Some(Ieee802154Pan(0xbeef));

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -47,7 +47,7 @@ use std::os::unix::io::AsRawFd;
 use std::str;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, RawSocket, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, RawSocket, wait as phy_wait};
 use xarxa::socket::tcp;
 use xarxa::wire::{EthernetAddress, Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr};
 
@@ -134,7 +134,7 @@ fn main() {
 
     let mut matches = utils::parse_options(&opts, free);
 
-    let device = RawSocket::new("wpan1", Medium::Ieee802154).unwrap();
+    let device = RawSocket::new("wpan1", DriverMedium::Ieee802154).unwrap();
 
     let fd = device.as_raw_fd();
     let mut device =
@@ -148,13 +148,14 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => Config::new(
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        DriverMedium::Ieee802154 => Config::new(
             Ieee802154Address::Extended([0x1a, 0x0b, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42]).into(),
         ),
+        medium => todo!("{medium:?}"),
     };
     config.random_seed = rand::random();
     config.pan_id = Some(Ieee802154Pan(0xbeef));

--- a/examples/slaac.rs
+++ b/examples/slaac.rs
@@ -3,7 +3,7 @@ mod utils;
 use std::os::unix::io::AsRawFd;
 
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Device, Medium, wait as phy_wait};
+use xarxa::phy::{Device, DriverMedium, wait as phy_wait};
 use xarxa::socket::udp;
 use xarxa::time::{Duration, Instant};
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr, Ipv6Address};
@@ -25,11 +25,11 @@ fn main() {
 
     // Create interface
     let mut config = match device.capabilities().medium {
-        Medium::Ethernet => {
+        DriverMedium::Ethernet => {
             Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
         }
-        Medium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
-        Medium::Ieee802154 => todo!(),
+        DriverMedium::Ip => Config::new(xarxa::wire::HardwareAddress::Ip),
+        medium => todo!("{medium:?}"),
     };
     config.slaac = true;
 

--- a/examples/tcpdump.rs
+++ b/examples/tcpdump.rs
@@ -2,15 +2,14 @@ use std::env;
 use std::os::unix::io::AsRawFd;
 use xarxa::phy::wait as phy_wait;
 use xarxa::phy::{Device, RawSocket, RxToken};
-use xarxa::time::Instant;
 use xarxa::wire::{EthernetFrame, PrettyPrinter};
 
 fn main() {
     let ifname = env::args().nth(1).unwrap();
-    let mut socket = RawSocket::new(ifname.as_ref(), xarxa::phy::Medium::Ethernet).unwrap();
+    let mut socket = RawSocket::new(ifname.as_ref(), xarxa::phy::DriverMedium::Ethernet).unwrap();
     loop {
         phy_wait(socket.as_raw_fd(), None).unwrap();
-        let (rx_token, _) = socket.receive(Instant::now()).unwrap();
+        let (rx_token, _) = socket.receive().unwrap();
         rx_token.consume(|buffer| {
             println!(
                 "{}",

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "phy-tuntap_interface")]
 use xarxa::phy::TunTapInterface;
-use xarxa::phy::{Device, FaultInjector, Medium, Tracer};
+use xarxa::phy::{Device, DriverMedium, FaultInjector, Tracer};
 use xarxa::phy::{PcapMode, PcapWriter};
 use xarxa::time::{Duration, Instant};
 
@@ -101,8 +101,8 @@ pub fn parse_tuntap_options(matches: &mut Matches) -> TunTapInterface {
     let tun = matches.opt_str("tun");
     let tap = matches.opt_str("tap");
     match (tun, tap) {
-        (Some(tun), None) => TunTapInterface::new(&tun, Medium::Ip).unwrap(),
-        (None, Some(tap)) => TunTapInterface::new(&tap, Medium::Ethernet).unwrap(),
+        (Some(tun), None) => TunTapInterface::new(&tun, DriverMedium::Ip).unwrap(),
+        (None, Some(tap)) => TunTapInterface::new(&tap, DriverMedium::Ethernet).unwrap(),
         _ => panic!("You must specify exactly one of --tun or --tap"),
     }
 }
@@ -200,14 +200,15 @@ where
         } else {
             PcapMode::Both
         },
+        Instant::now,
     );
 
-    let device = Tracer::new(device, |_timestamp, _printer| {
+    let device = Tracer::new(device, |_printer| {
         #[cfg(feature = "log")]
         trace!("{}", _printer);
     });
 
-    let mut device = FaultInjector::new(device, seed);
+    let mut device = FaultInjector::new(device, seed, Instant::now);
     device.set_drop_chance(drop_chance);
     device.set_corrupt_chance(corrupt_chance);
     device.set_max_packet_size(size_limit);

--- a/fuzz/fuzz_targets/iface.rs
+++ b/fuzz/fuzz_targets/iface.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use xarxa::iface::{Config, Interface, SocketSet};
-use xarxa::phy::{Loopback, Medium};
+use xarxa::phy::{DriverMedium, Loopback};
 use xarxa::socket::tcp;
 use xarxa::time::{Duration, Instant};
 use xarxa::wire::{EthernetAddress, IpAddress, IpCidr};
@@ -13,23 +13,34 @@ use xarxa::phy::{PcapMode, PcapWriter, Tracer};
 
 mod mock {
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::Arc;
     use xarxa::time::{Duration, Instant};
 
+    /// Milliseconds since the clock was created.
+    ///
+    /// This is a global rather than a field of [`Clock`] so that [`now`] can be passed as a
+    /// plain `fn() -> Instant` to the phy middleware.
+    static NOW: AtomicU64 = AtomicU64::new(0);
+
+    /// The current mock time.
+    pub fn now() -> Instant {
+        Instant::from_millis(NOW.load(Ordering::SeqCst) as i64)
+    }
+
     #[derive(Debug, Clone)]
-    pub struct Clock(Arc<AtomicU64>);
+    pub struct Clock;
 
     impl Clock {
         pub fn new() -> Clock {
-            Clock(Arc::new(AtomicU64::new(0)))
+            NOW.store(0, Ordering::SeqCst);
+            Clock
         }
 
         pub fn advance(&self, duration: Duration) {
-            self.0.fetch_add(duration.total_millis(), Ordering::SeqCst);
+            NOW.fetch_add(duration.total_millis(), Ordering::SeqCst);
         }
 
         pub fn elapsed(&self) -> Instant {
-            Instant::from_millis(self.0.load(Ordering::SeqCst) as i64)
+            now()
         }
     }
 }
@@ -91,7 +102,7 @@ fuzz_target!(|data: &[u8]| {
 
     let clock = mock::Clock::new();
 
-    let device = Loopback::new(Medium::Ethernet);
+    let device = Loopback::new(DriverMedium::Ethernet);
     let device = xarxa::phy::FuzzInjector::new(device, EmptyFuzzer(), TcpHeaderFuzzer::new(data));
 
     #[cfg(feature = "log")]
@@ -99,10 +110,11 @@ fuzz_target!(|data: &[u8]| {
         device,
         File::create("fuzz.pcap").expect("cannot open file"),
         PcapMode::Both,
+        mock::now,
     );
 
     #[cfg(feature = "log")]
-    let device = Tracer::new(device, |_timestamp, _printer| {
+    let device = Tracer::new(device, |_printer| {
         log::trace!("{}", _printer);
     });
 

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -19,7 +19,7 @@ impl Interface {
 
         let pkt = &self.fragmenter;
         if pkt.packet_len > pkt.sent_bytes
-            && let Some(tx_token) = device.transmit(self.inner.now)
+            && let Some(tx_token) = device.transmit()
         {
             self.inner
                 .dispatch_ipv4_frag(tx_token, &mut self.fragmenter);
@@ -156,9 +156,7 @@ impl InterfaceInner {
         {
             use crate::socket::dhcpv4::Socket as Dhcpv4Socket;
 
-            if ipv4_repr.next_header == IpProtocol::Udp
-                && matches!(self.caps.medium, Medium::Ethernet)
-            {
+            if ipv4_repr.next_header == IpProtocol::Udp && matches!(self.medium, Medium::Ethernet) {
                 let udp_packet = check!(UdpPacket::new_checked(ip_payload));
                 if let Some(dhcp_socket) = sockets
                     .items_mut()
@@ -421,7 +419,7 @@ impl InterfaceInner {
     pub(super) fn dispatch_ipv4_frag<Tx: TxToken>(&mut self, tx_token: Tx, frag: &mut Fragmenter) {
         let caps = self.caps.clone();
 
-        let max_fragment_size = caps.max_ipv4_fragment_size(frag.ipv4.repr.buffer_len());
+        let max_fragment_size = self.max_ipv4_fragment_size(frag.ipv4.repr.buffer_len());
         let payload_len = (frag.packet_len - frag.sent_bytes).min(max_fragment_size);
         let ip_len = payload_len + frag.ipv4.repr.buffer_len();
 
@@ -431,7 +429,7 @@ impl InterfaceInner {
 
         let mut tx_len = ip_len;
         #[cfg(feature = "medium-ethernet")]
-        if matches!(caps.medium, Medium::Ethernet) {
+        if matches!(self.medium, Medium::Ethernet) {
             tx_len += EthernetFrame::<&[u8]>::header_len();
         }
 
@@ -454,7 +452,7 @@ impl InterfaceInner {
 
         tx_token.consume(tx_len, |mut tx_buffer| {
             #[cfg(feature = "medium-ethernet")]
-            if matches!(self.caps.medium, Medium::Ethernet) {
+            if matches!(self.medium, Medium::Ethernet) {
                 emit_ethernet(&IpRepr::Ipv4(frag.ipv4.repr), tx_buffer);
                 tx_buffer = &mut tx_buffer[EthernetFrame::<&[u8]>::header_len()..];
             }

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -417,7 +417,7 @@ impl InterfaceInner {
 
             // Forward any NDISC packets to the ndisc packet handler
             #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-            Icmpv6Repr::Ndisc(repr) if ip_repr.hop_limit == 0xff => match self.caps.medium {
+            Icmpv6Repr::Ndisc(repr) if ip_repr.hop_limit == 0xff => match self.medium {
                 #[cfg(feature = "medium-ethernet")]
                 Medium::Ethernet => self.process_ndisc(ip_repr, repr),
                 #[cfg(feature = "medium-ieee802154")]
@@ -461,7 +461,7 @@ impl InterfaceInner {
             } => {
                 let ip_addr = ip_repr.src_addr.into();
                 if let Some(lladdr) = lladdr {
-                    let lladdr = check!(lladdr.parse(self.caps.medium));
+                    let lladdr = check!(lladdr.parse(self.medium));
                     if !lladdr.is_unicast() || !target_addr.x_is_unicast() {
                         return None;
                     }
@@ -479,7 +479,7 @@ impl InterfaceInner {
                 ..
             } => {
                 if let Some(lladdr) = lladdr {
-                    let lladdr = check!(lladdr.parse(self.caps.medium));
+                    let lladdr = check!(lladdr.parse(self.medium));
                     if !lladdr.is_unicast() || !target_addr.x_is_unicast() {
                         return None;
                     }
@@ -724,7 +724,7 @@ impl Interface {
             hop_limit: 255,
         };
         let packet = Packet::new_ipv6(ipv6_repr, IpPayload::Icmpv6(rs_repr));
-        let Some(tx_token) = device.transmit(self.inner.now) else {
+        let Some(tx_token) = device.transmit() else {
             return;
         };
         // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -127,6 +127,8 @@ pub struct Interface {
 /// exclusively). However, it is still possible to call methods on its `inner` field.
 pub struct InterfaceInner {
     caps: DeviceCapabilities,
+    /// Medium of the device, converted once from `caps.medium`.
+    medium: Medium,
     now: Instant,
     rand: Rand,
 
@@ -206,9 +208,10 @@ impl Interface {
     /// the medium of the device.
     pub fn new(config: Config, device: &mut (impl Device + ?Sized), now: Instant) -> Self {
         let caps = device.capabilities();
+        let medium = Medium::from_driver(caps.medium);
         assert_eq!(
             config.hardware_addr.medium(),
-            caps.medium,
+            medium,
             "The hardware address does not match the medium of the interface."
         );
 
@@ -260,6 +263,7 @@ impl Interface {
             inner: InterfaceInner {
                 now,
                 caps,
+                medium,
                 hardware_addr: config.hardware_addr,
                 ip_addrs: Vec::new(),
                 any_ip: false,
@@ -303,15 +307,12 @@ impl Interface {
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
     pub fn hardware_addr(&self) -> HardwareAddress {
         #[cfg(all(feature = "medium-ethernet", not(feature = "medium-ieee802154")))]
-        assert!(self.inner.caps.medium == Medium::Ethernet);
+        assert!(self.inner.medium == Medium::Ethernet);
         #[cfg(all(feature = "medium-ieee802154", not(feature = "medium-ethernet")))]
-        assert!(self.inner.caps.medium == Medium::Ieee802154);
+        assert!(self.inner.medium == Medium::Ieee802154);
 
         #[cfg(all(feature = "medium-ieee802154", feature = "medium-ethernet"))]
-        assert!(
-            self.inner.caps.medium == Medium::Ethernet
-                || self.inner.caps.medium == Medium::Ieee802154
-        );
+        assert!(self.inner.medium == Medium::Ethernet || self.inner.medium == Medium::Ieee802154);
 
         self.inner.hardware_addr
     }
@@ -324,15 +325,12 @@ impl Interface {
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
     pub fn set_hardware_addr(&mut self, addr: HardwareAddress) {
         #[cfg(all(feature = "medium-ethernet", not(feature = "medium-ieee802154")))]
-        assert!(self.inner.caps.medium == Medium::Ethernet);
+        assert!(self.inner.medium == Medium::Ethernet);
         #[cfg(all(feature = "medium-ieee802154", not(feature = "medium-ethernet")))]
-        assert!(self.inner.caps.medium == Medium::Ieee802154);
+        assert!(self.inner.medium == Medium::Ieee802154);
 
         #[cfg(all(feature = "medium-ieee802154", feature = "medium-ethernet"))]
-        assert!(
-            self.inner.caps.medium == Medium::Ethernet
-                || self.inner.caps.medium == Medium::Ieee802154
-        );
+        assert!(self.inner.medium == Medium::Ethernet || self.inner.medium == Medium::Ieee802154);
 
         InterfaceInner::check_hardware_addr(&addr);
         self.inner.hardware_addr = addr;
@@ -393,7 +391,7 @@ impl Interface {
             feature = "multicast",
             feature = "medium-ethernet"
         ))]
-        if self.inner.caps.medium == Medium::Ethernet {
+        if self.inner.medium == Medium::Ethernet {
             self.update_solicited_node_groups();
         }
     }
@@ -511,7 +509,7 @@ impl Interface {
     ) -> PollResult {
         self.inner.now = timestamp;
 
-        match self.inner.caps.medium {
+        match self.inner.medium {
             #[cfg(feature = "medium-ieee802154")]
             Medium::Ieee802154 => {
                 #[cfg(feature = "proto-sixlowpan-fragmentation")]
@@ -633,7 +631,7 @@ impl Interface {
         device: &mut (impl Device + ?Sized),
         sockets: &mut SocketSet<'_>,
     ) -> PollIngressSingleResult {
-        let Some((rx_token, tx_token)) = device.receive(self.inner.now) else {
+        let Some((rx_token, tx_token)) = device.receive() else {
             return PollIngressSingleResult::None;
         };
 
@@ -643,7 +641,7 @@ impl Interface {
                 return PollIngressSingleResult::PacketProcessed;
             }
 
-            match self.inner.caps.medium {
+            match self.inner.medium {
                 #[cfg(feature = "medium-ethernet")]
                 Medium::Ethernet => {
                     if let Some(packet) =
@@ -721,7 +719,7 @@ impl Interface {
             let mut neighbor_addr = None;
             let mut respond = |inner: &mut InterfaceInner, meta: PacketMeta, response: Packet| {
                 neighbor_addr = Some(response.ip_repr().dst_addr());
-                let t = device.transmit(inner.now).ok_or_else(|| {
+                let t = device.transmit().ok_or_else(|| {
                     net_debug!("failed to transmit IP: device exhausted");
                     EgressError::Exhausted
                 })?;
@@ -798,7 +796,7 @@ impl Interface {
             };
 
             match result {
-                Err(EgressError::Exhausted) => break, // Device buffer full.
+                Err(EgressError::Exhausted) => break, // Driver buffer full.
                 Err(EgressError::Dispatch) => {
                     // `NeighborCache` already takes care of rate limiting the neighbor discovery
                     // requests from the socket. However, without an additional rate limiting
@@ -835,7 +833,24 @@ impl InterfaceInner {
 
     #[allow(unused)] // unused depending on which sockets are enabled
     pub(crate) fn ip_mtu(&self) -> usize {
-        self.caps.ip_mtu()
+        match self.medium {
+            #[cfg(feature = "medium-ethernet")]
+            Medium::Ethernet => {
+                self.caps.max_transmission_unit - EthernetFrame::<&[u8]>::header_len()
+            }
+            #[cfg(feature = "medium-ip")]
+            Medium::Ip => self.caps.max_transmission_unit,
+            // TODO(thvdveld): what is the MTU for Medium::Ieee802154?
+            #[cfg(feature = "medium-ieee802154")]
+            Medium::Ieee802154 => self.caps.max_transmission_unit,
+        }
+    }
+
+    /// The maximum IPv4 payload fragment size, aligned per spec.
+    #[cfg(feature = "proto-ipv4-fragmentation")]
+    pub(crate) fn max_ipv4_fragment_size(&self, ip_header_len: usize) -> usize {
+        let payload_mtu = self.ip_mtu() - ip_header_len;
+        payload_mtu - (payload_mtu % crate::phy::IPV4_FRAGMENT_PAYLOAD_ALIGNMENT)
     }
 
     #[allow(unused)] // unused depending on which sockets are enabled, and in tests
@@ -1025,7 +1040,7 @@ impl InterfaceInner {
 
     fn has_neighbor(&self, addr: &IpAddress) -> bool {
         match self.route(addr, self.now) {
-            Some(_routed_addr) => match self.caps.medium {
+            Some(_routed_addr) => match self.medium {
                 #[cfg(feature = "medium-ethernet")]
                 Medium::Ethernet => self.neighbor_cache.lookup(&_routed_addr, self.now).found(),
                 #[cfg(feature = "medium-ieee802154")]
@@ -1048,7 +1063,7 @@ impl InterfaceInner {
         Tx: TxToken,
     {
         if self.is_broadcast(dst_addr) {
-            let hardware_addr = match self.caps.medium {
+            let hardware_addr = match self.medium {
                 #[cfg(feature = "medium-ethernet")]
                 Medium::Ethernet => HardwareAddress::Ethernet(EthernetAddress::BROADCAST),
                 #[cfg(feature = "medium-ieee802154")]
@@ -1063,7 +1078,7 @@ impl InterfaceInner {
         if dst_addr.is_multicast() {
             let hardware_addr = match *dst_addr {
                 #[cfg(feature = "proto-ipv4")]
-                IpAddress::Ipv4(addr) => match self.caps.medium {
+                IpAddress::Ipv4(addr) => match self.medium {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         let b = addr.octets();
@@ -1082,7 +1097,7 @@ impl InterfaceInner {
                     Medium::Ip => unreachable!(),
                 },
                 #[cfg(feature = "proto-ipv6")]
-                IpAddress::Ipv6(addr) => match self.caps.medium {
+                IpAddress::Ipv6(addr) => match self.medium {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         let b = addr.octets();
@@ -1115,7 +1130,7 @@ impl InterfaceInner {
 
         match dst_addr {
             #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv4"))]
-            IpAddress::Ipv4(dst_addr) if matches!(self.caps.medium, Medium::Ethernet) => {
+            IpAddress::Ipv4(dst_addr) if matches!(self.medium, Medium::Ethernet) => {
                 net_debug!(
                     "address {} not in neighbor cache, sending ARP request",
                     dst_addr
@@ -1205,7 +1220,7 @@ impl InterfaceInner {
         // Dispatch IEEE802.15.4:
 
         #[cfg(feature = "medium-ieee802154")]
-        if matches!(self.caps.medium, Medium::Ieee802154) {
+        if matches!(self.medium, Medium::Ieee802154) {
             let (addr, tx_token) =
                 self.lookup_hardware_addr(tx_token, &ip_repr.dst_addr(), frag)?;
             let addr = addr.ieee802154_or_panic();
@@ -1226,13 +1241,13 @@ impl InterfaceInner {
 
         // Add the size of the Ethernet header if the medium is Ethernet.
         #[cfg(feature = "medium-ethernet")]
-        if matches!(self.caps.medium, Medium::Ethernet) {
+        if matches!(self.medium, Medium::Ethernet) {
             total_len = EthernetFrame::<&[u8]>::buffer_len(total_len);
         }
 
         // If the medium is Ethernet, then we need to retrieve the destination hardware address.
         #[cfg(feature = "medium-ethernet")]
-        let (dst_hardware_addr, mut tx_token) = match self.caps.medium {
+        let (dst_hardware_addr, mut tx_token) = match self.medium {
             Medium::Ethernet => {
                 match self.lookup_hardware_addr(tx_token, &ip_repr.dst_addr(), frag)? {
                     (HardwareAddress::Ethernet(addr), tx_token) => (addr, tx_token),
@@ -1273,7 +1288,7 @@ impl InterfaceInner {
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(repr) => {
                 // If we have an IPv4 packet, then we need to check if we need to fragment it.
-                if total_ip_len > self.caps.ip_mtu() {
+                if total_ip_len > self.ip_mtu() {
                     #[cfg(feature = "proto-ipv4-fragmentation")]
                     {
                         net_debug!("start fragmentation");
@@ -1281,12 +1296,11 @@ impl InterfaceInner {
                         // Calculate how much we will send now (including the Ethernet header).
 
                         let ip_header_len = repr.buffer_len();
-                        let first_frag_data_len =
-                            self.caps.max_ipv4_fragment_size(repr.buffer_len());
+                        let first_frag_data_len = self.max_ipv4_fragment_size(repr.buffer_len());
                         let first_frag_ip_len = first_frag_data_len + ip_header_len;
                         let mut tx_len = first_frag_ip_len;
                         #[cfg(feature = "medium-ethernet")]
-                        if matches!(caps.medium, Medium::Ethernet) {
+                        if matches!(self.medium, Medium::Ethernet) {
                             tx_len += EthernetFrame::<&[u8]>::header_len();
                         }
 
@@ -1333,7 +1347,7 @@ impl InterfaceInner {
                         // Transmit the first packet.
                         tx_token.consume(tx_len, |mut tx_buffer| {
                             #[cfg(feature = "medium-ethernet")]
-                            if matches!(self.caps.medium, Medium::Ethernet) {
+                            if matches!(self.medium, Medium::Ethernet) {
                                 emit_ethernet(&ip_repr, tx_buffer);
                                 tx_buffer = &mut tx_buffer[EthernetFrame::<&[u8]>::header_len()..];
                             }
@@ -1362,7 +1376,7 @@ impl InterfaceInner {
                     // No fragmentation is required.
                     tx_token.consume(total_len, |mut tx_buffer| {
                         #[cfg(feature = "medium-ethernet")]
-                        if matches!(self.caps.medium, Medium::Ethernet) {
+                        if matches!(self.medium, Medium::Ethernet) {
                             emit_ethernet(&ip_repr, tx_buffer);
                             tx_buffer = &mut tx_buffer[EthernetFrame::<&[u8]>::header_len()..];
                         }
@@ -1377,13 +1391,13 @@ impl InterfaceInner {
             #[cfg(feature = "proto-ipv6")]
             IpRepr::Ipv6(_) => {
                 // Check if we need to fragment it.
-                if total_ip_len > self.caps.ip_mtu() {
+                if total_ip_len > self.ip_mtu() {
                     net_debug!("IPv6 fragmentation support is unimplemented. Dropping.");
                     Ok(())
                 } else {
                     tx_token.consume(total_len, |mut tx_buffer| {
                         #[cfg(feature = "medium-ethernet")]
-                        if matches!(self.caps.medium, Medium::Ethernet) {
+                        if matches!(self.medium, Medium::Ethernet) {
                             emit_ethernet(&ip_repr, tx_buffer);
                             tx_buffer = &mut tx_buffer[EthernetFrame::<&[u8]>::header_len()..];
                         }

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -196,7 +196,7 @@ impl Interface {
                 #[cfg(feature = "proto-ipv4")]
                 IpAddress::Ipv4(addr) => {
                     if let Some(pkt) = self.inner.igmp_report_packet(IgmpVersion::Version2, addr) {
-                        let Some(tx_token) = device.transmit(self.inner.now) else {
+                        let Some(tx_token) = device.transmit() else {
                             break;
                         };
 
@@ -212,7 +212,7 @@ impl Interface {
                         MldRecordType::ChangeToInclude,
                         addr,
                     )]) {
-                        let Some(tx_token) = device.transmit(self.inner.now) else {
+                        let Some(tx_token) = device.transmit() else {
                             break;
                         };
 
@@ -244,7 +244,7 @@ impl Interface {
                 #[cfg(feature = "proto-ipv4")]
                 IpAddress::Ipv4(addr) => {
                     if let Some(pkt) = self.inner.igmp_leave_packet(addr) {
-                        let Some(tx_token) = device.transmit(self.inner.now) else {
+                        let Some(tx_token) = device.transmit() else {
                             break;
                         };
 
@@ -260,7 +260,7 @@ impl Interface {
                         MldRecordType::ChangeToExclude,
                         addr,
                     )]) {
-                        let Some(tx_token) = device.transmit(self.inner.now) else {
+                        let Some(tx_token) = device.transmit() else {
                             break;
                         };
 
@@ -284,7 +284,7 @@ impl Interface {
             } if self.inner.now >= timeout => {
                 if let Some(pkt) = self.inner.igmp_report_packet(version, group) {
                     // Send initial membership report
-                    if let Some(tx_token) = device.transmit(self.inner.now) {
+                    if let Some(tx_token) = device.transmit() {
                         // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
                         self.inner
                             .dispatch_ip(tx_token, PacketMeta::default(), pkt, &mut self.fragmenter)
@@ -315,7 +315,7 @@ impl Interface {
                     Some(addr) => {
                         if let Some(pkt) = self.inner.igmp_report_packet(version, addr) {
                             // Send initial membership report
-                            if let Some(tx_token) = device.transmit(self.inner.now) {
+                            if let Some(tx_token) = device.transmit() {
                                 // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
                                 self.inner
                                     .dispatch_ip(
@@ -362,7 +362,7 @@ impl Interface {
                     })
                     .collect::<heapless::Vec<_, IFACE_MAX_MULTICAST_GROUP_COUNT>>();
                 if let Some(pkt) = self.inner.mldv2_report_packet(&records)
-                    && let Some(tx_token) = device.transmit(self.inner.now)
+                    && let Some(tx_token) = device.transmit()
                 {
                     self.inner
                         .dispatch_ip(tx_token, PacketMeta::default(), pkt, &mut self.fragmenter)
@@ -373,7 +373,7 @@ impl Interface {
             MldReportState::ToSpecificQuery { group, timeout } if self.inner.now >= timeout => {
                 let record = MldAddressRecordRepr::new(MldRecordType::ModeIsExclude, group);
                 if let Some(pkt) = self.inner.mldv2_report_packet(&[record])
-                    && let Some(tx_token) = device.transmit(self.inner.now)
+                    && let Some(tx_token) = device.transmit()
                 {
                     // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
                     self.inner

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -20,7 +20,7 @@ impl Interface {
 
         let pkt = &self.fragmenter;
         if pkt.packet_len > pkt.sent_bytes
-            && let Some(tx_token) = device.transmit(self.inner.now)
+            && let Some(tx_token) = device.transmit()
         {
             self.inner
                 .dispatch_ieee802154_frag(tx_token, &mut self.fragmenter);

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -724,7 +724,7 @@ fn test_handle_igmp(#[case] medium: Medium) {
         recv_all(device, timestamp)
             .iter()
             .filter_map(|frame| {
-                let ipv4_packet = match caps.medium {
+                let ipv4_packet = match device.medium() {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         let eth_frame = EthernetFrame::new_checked(frame).ok()?;
@@ -1539,11 +1539,12 @@ use crate::wire::ipv4::HEADER_LEN;
 #[rstest]
 #[cfg(all(feature = "medium-ip", feature = "proto-ipv4-fragmentation",))]
 fn test_ipv4_fragment_size() {
-    let (_, _, device) = setup(Medium::Ip);
-    let caps = device.capabilities();
+    let (iface, _, _) = setup(Medium::Ip);
     for i in 0..IPV4_FRAGMENT_PAYLOAD_ALIGNMENT {
         assert!(
-            caps.max_ipv4_fragment_size(HEADER_LEN + i)
+            iface
+                .inner
+                .max_ipv4_fragment_size(HEADER_LEN + i)
                 .is_multiple_of(IPV4_FRAGMENT_PAYLOAD_ALIGNMENT)
         );
     }

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -849,11 +849,10 @@ fn test_router_advertisement(#[case] medium: Medium) {
         device: &mut crate::tests::TestingDevice,
         timestamp: Instant,
     ) -> std::vec::Vec<Ipv6Packet<std::vec::Vec<u8>>> {
-        let caps = device.capabilities();
         recv_all(device, timestamp)
             .iter()
             .filter_map(|frame| {
-                let ipv6_packet = match caps.medium {
+                let ipv6_packet = match device.medium() {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         let eth_frame = EthernetFrame::new_checked(frame).ok()?;
@@ -1529,11 +1528,10 @@ fn test_join_ipv6_multicast_group(#[case] medium: Medium) {
         device: &mut crate::tests::TestingDevice,
         timestamp: Instant,
     ) -> std::vec::Vec<Ipv6Packet<std::vec::Vec<u8>>> {
-        let caps = device.capabilities();
         recv_all(device, timestamp)
             .iter()
             .filter_map(|frame| {
-                let ipv6_packet = match caps.medium {
+                let ipv6_packet = match device.medium() {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         let eth_frame = EthernetFrame::new_checked(frame).ok()?;
@@ -1656,11 +1654,10 @@ fn test_handle_valid_multicast_query(#[case] medium: Medium) {
         device: &mut crate::tests::TestingDevice,
         timestamp: Instant,
     ) -> std::vec::Vec<Ipv6Packet<std::vec::Vec<u8>>> {
-        let caps = device.capabilities();
         recv_all(device, timestamp)
             .iter()
             .filter_map(|frame| {
-                let ipv6_packet = match caps.medium {
+                let ipv6_packet = match device.medium() {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         let eth_frame = EthernetFrame::new_checked(frame).ok()?;

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -54,7 +54,7 @@ impl TxToken for MockTxToken {
 #[should_panic(expected = "The hardware address does not match the medium of the interface.")]
 #[cfg(all(feature = "medium-ip", feature = "medium-ethernet", feature = "alloc"))]
 fn test_new_panic() {
-    let mut device = Loopback::new(Medium::Ethernet);
+    let mut device = Loopback::new(Medium::Ethernet.to_driver());
     let config = Config::new(HardwareAddress::Ip);
     Interface::new(config, &mut device, Instant::ZERO);
 }

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -95,7 +95,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
     // computed.
     iface.inner.caps.checksum.icmpv6 = Checksum::None;
 
-    assert_eq!(iface.inner.caps.medium, Medium::Ieee802154);
+    assert_eq!(iface.inner.medium, Medium::Ieee802154);
     let now = iface.inner.now();
 
     iface.inner.neighbor_cache.fill(
@@ -222,7 +222,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
         Instant::now(),
     );
 
-    let tx_token = device.transmit(Instant::now()).unwrap();
+    let tx_token = device.transmit().unwrap();
     iface.inner.dispatch_ieee802154(
         Ieee802154Address::default(),
         tx_token,
@@ -371,7 +371,7 @@ In at rhoncus tortor. Cras blandit tellus diam, varius vestibulum nibh commodo n
         ))
     );
 
-    let tx_token = device.transmit(Instant::now()).unwrap();
+    let tx_token = device.transmit().unwrap();
     iface.inner.dispatch_ieee802154(
         Ieee802154Address::default(),
         tx_token,

--- a/src/phy/fault_injector.rs
+++ b/src/phy/fault_injector.rs
@@ -97,12 +97,16 @@ pub struct FaultInjector<D: Device> {
     inner: D,
     state: State,
     config: Config,
+    clock: fn() -> Instant,
     rx_buf: [u8; MTU],
 }
 
 impl<D: Device> FaultInjector<D> {
     /// Create a fault injector device, using the given random number generator seed.
-    pub fn new(inner: D, seed: u32) -> FaultInjector<D> {
+    ///
+    /// `clock` is only used for rate limiting, see [`Self::set_max_tx_rate`] and
+    /// [`Self::set_max_rx_rate`]. Under `std`, [`Instant::now`] is a suitable value.
+    pub fn new(inner: D, seed: u32, clock: fn() -> Instant) -> FaultInjector<D> {
         FaultInjector {
             inner,
             state: State {
@@ -112,6 +116,7 @@ impl<D: Device> FaultInjector<D> {
                 rx_bucket: 0,
             },
             config: Config::default(),
+            clock,
             rx_buf: [0u8; MTU],
         }
     }
@@ -213,8 +218,8 @@ impl<D: Device> Device for FaultInjector<D> {
         caps
     }
 
-    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        let (rx_token, tx_token) = self.inner.receive(timestamp)?;
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let (rx_token, tx_token) = self.inner.receive()?;
         let rx_meta = <D::RxToken<'_> as phy::RxToken>::meta(&rx_token);
 
         let len = super::RxToken::consume(rx_token, |buffer| {
@@ -235,7 +240,7 @@ impl<D: Device> Device for FaultInjector<D> {
             return None;
         }
 
-        if !self.state.maybe_receive(&self.config, timestamp) {
+        if !self.state.maybe_receive(&self.config, (self.clock)()) {
             net_trace!("rx: dropping a packet because of rate limiting");
             return None;
         }
@@ -251,18 +256,19 @@ impl<D: Device> Device for FaultInjector<D> {
             config: self.config,
             token: tx_token,
             junk: [0; MTU],
-            timestamp,
+            clock: self.clock,
         };
         Some((rx, tx))
     }
 
-    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
-        self.inner.transmit(timestamp).map(|token| TxToken {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
+        let clock = self.clock;
+        self.inner.transmit().map(|token| TxToken {
             state: &mut self.state,
             config: self.config,
             token,
             junk: [0; MTU],
-            timestamp,
+            clock,
         })
     }
 }
@@ -292,7 +298,7 @@ pub struct TxToken<'a, Tx: phy::TxToken> {
     config: Config,
     token: Tx,
     junk: [u8; MTU],
-    timestamp: Instant,
+    clock: fn() -> Instant,
 }
 
 impl<'a, Tx: phy::TxToken> phy::TxToken for TxToken<'a, Tx> {
@@ -306,7 +312,7 @@ impl<'a, Tx: phy::TxToken> phy::TxToken for TxToken<'a, Tx> {
         } else if self.config.max_size > 0 && len > self.config.max_size {
             net_trace!("tx: dropping a packet that is too large");
             true
-        } else if !self.state.maybe_transmit(&self.config, self.timestamp) {
+        } else if !self.state.maybe_transmit(&self.config, (self.clock)()) {
             net_trace!("tx: dropping a packet because of rate limiting");
             true
         } else {

--- a/src/phy/fuzz_injector.rs
+++ b/src/phy/fuzz_injector.rs
@@ -1,5 +1,4 @@
 use crate::phy::{self, Device, DeviceCapabilities};
-use crate::time::Instant;
 use alloc::vec::Vec;
 
 // This could be fixed once associated consts are stable.
@@ -64,8 +63,8 @@ where
         caps
     }
 
-    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        self.inner.receive(timestamp).map(|(rx_token, tx_token)| {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        self.inner.receive().map(|(rx_token, tx_token)| {
             let rx = RxToken {
                 fuzzer: &mut self.fuzz_rx,
                 token: rx_token,
@@ -78,8 +77,8 @@ where
         })
     }
 
-    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
-        self.inner.transmit(timestamp).map(|token| TxToken {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
+        self.inner.transmit().map(|token| TxToken {
             fuzzer: &mut self.fuzz_tx,
             token: token,
         })

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -2,14 +2,13 @@ use alloc::collections::VecDeque;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use crate::phy::{self, ChecksumCapabilities, Device, DeviceCapabilities, Medium};
-use crate::time::Instant;
+use crate::phy::{self, ChecksumCapabilities, Device, DeviceCapabilities, DriverMedium};
 
 /// A loopback device.
 #[derive(Debug)]
 pub struct Loopback {
     pub(crate) queue: VecDeque<Vec<u8>>,
-    medium: Medium,
+    medium: DriverMedium,
 }
 
 #[allow(clippy::new_without_default)]
@@ -18,7 +17,7 @@ impl Loopback {
     ///
     /// Every packet transmitted through this device will be received through it
     /// in FIFO order.
-    pub fn new(medium: Medium) -> Loopback {
+    pub fn new(medium: DriverMedium) -> Loopback {
         Loopback {
             queue: VecDeque::new(),
             medium,
@@ -31,15 +30,14 @@ impl Device for Loopback {
     type TxToken<'a> = TxToken<'a>;
 
     fn capabilities(&self) -> DeviceCapabilities {
-        DeviceCapabilities {
-            max_transmission_unit: 65535,
-            medium: self.medium,
-            checksum: ChecksumCapabilities::ignored(),
-            ..DeviceCapabilities::default()
-        }
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = 65535;
+        caps.medium = self.medium;
+        caps.checksum = ChecksumCapabilities::ignored();
+        caps
     }
 
-    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         self.queue.pop_front().map(move |buffer| {
             let rx = RxToken { buffer };
             let tx = TxToken {
@@ -49,7 +47,7 @@ impl Device for Loopback {
         })
     }
 
-    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             queue: &mut self.queue,
         })

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -1,8 +1,11 @@
 /*! Access to networking hardware.
 
-The `phy` module deals with the *network devices*. It provides a trait
-for transmitting and receiving frames, [Device](trait.Device.html)
-and implementations of it:
+The `phy` module deals with the *network devices*. The [Driver] trait, and the types
+appearing in its signature, live in the separate [`xarxa-driver`](xarxa_driver) crate,
+and are re-exported here. Driver crates should depend on `xarxa-driver` rather than on
+`xarxa`, so that they don't need to be updated for every breaking change in `xarxa`
+
+This module provides implementations of [Driver]:
 
   * the [_loopback_](struct.Loopback.html), for zero dependency testing;
   * _middleware_ [Tracer](struct.Tracer.html) and
@@ -11,84 +14,72 @@ and implementations of it:
     [TunTapInterface](struct.TunTapInterface.html), to transmit and receive frames
     on the host OS.
 */
-#![cfg_attr(
-    feature = "medium-ethernet",
-    doc = r##"
-# Examples
 
-An implementation of the [Device](trait.Device.html) trait for a simple hardware
-Ethernet controller could look as follows:
+pub use xarxa_driver::{
+    Checksum, ChecksumCapabilities, Device, DeviceCapabilities, PacketMeta, RxToken, Timestamp,
+    TxToken,
+};
 
-```rust
-use xarxa::phy::{self, DeviceCapabilities, Device, Medium};
-use xarxa::time::Instant;
+/// Type of medium of a driver, as reported in [`DeviceCapabilities::medium`].
+///
+/// This always has all its variants, regardless of which Cargo features `xarxa` is built with,
+/// because a driver crate cannot know what the stack it is used with was built for. See
+/// [`Medium`] for the stack-internal counterpart.
+pub use xarxa_driver::Medium as DriverMedium;
 
-struct StmPhy {
-    rx_buffer: [u8; 1536],
-    tx_buffer: [u8; 1536],
+/// Type of medium of an interface.
+///
+/// This is the stack-internal counterpart of [`xarxa_driver::Medium`]: it only has variants for the
+/// mediums the stack was built for, so that when a single `medium-*` Cargo feature is enabled
+/// it becomes a zero-sized type and all the matches on it are compiled away.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Medium {
+    /// See [`DriverMedium::Ethernet`].
+    #[cfg(feature = "medium-ethernet")]
+    Ethernet,
+
+    /// See [`DriverMedium::Ip`].
+    #[cfg(feature = "medium-ip")]
+    Ip,
+
+    /// See [`DriverMedium::Ieee802154`].
+    #[cfg(feature = "medium-ieee802154")]
+    Ieee802154,
 }
 
-impl<'a> StmPhy {
-    fn new() -> StmPhy {
-        StmPhy {
-            rx_buffer: [0; 1536],
-            tx_buffer: [0; 1536],
+impl Medium {
+    /// Convert from the medium reported by a driver.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the corresponding `medium-*` Cargo feature is not enabled.
+    pub fn from_driver(medium: DriverMedium) -> Self {
+        match medium {
+            #[cfg(feature = "medium-ethernet")]
+            DriverMedium::Ethernet => Self::Ethernet,
+            #[cfg(feature = "medium-ip")]
+            DriverMedium::Ip => Self::Ip,
+            #[cfg(feature = "medium-ieee802154")]
+            DriverMedium::Ieee802154 => Self::Ieee802154,
+            medium => panic!(
+                "The driver's medium is {medium:?}, but xarxa was built without support for it. Enable the corresponding `medium-*` Cargo feature."
+            ),
+        }
+    }
+
+    /// Convert to the medium a driver reports.
+    pub fn to_driver(self) -> DriverMedium {
+        match self {
+            #[cfg(feature = "medium-ethernet")]
+            Self::Ethernet => DriverMedium::Ethernet,
+            #[cfg(feature = "medium-ip")]
+            Self::Ip => DriverMedium::Ip,
+            #[cfg(feature = "medium-ieee802154")]
+            Self::Ieee802154 => DriverMedium::Ieee802154,
         }
     }
 }
-
-impl phy::Device for StmPhy {
-    type RxToken<'a> = StmPhyRxToken<'a> where Self: 'a;
-    type TxToken<'a> = StmPhyTxToken<'a> where Self: 'a;
-
-    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        Some((StmPhyRxToken(&mut self.rx_buffer[..]),
-              StmPhyTxToken(&mut self.tx_buffer[..])))
-    }
-
-    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
-        Some(StmPhyTxToken(&mut self.tx_buffer[..]))
-    }
-
-    fn capabilities(&self) -> DeviceCapabilities {
-        let mut caps = DeviceCapabilities::default();
-        caps.max_transmission_unit = 1536;
-        caps.max_burst_size = Some(1);
-        caps.medium = Medium::Ethernet;
-        caps
-    }
-}
-
-struct StmPhyRxToken<'a>(&'a mut [u8]);
-
-impl<'a> phy::RxToken for StmPhyRxToken<'a> {
-    fn consume<R, F>(self, f: F) -> R
-        where F: FnOnce(& [u8]) -> R
-    {
-        // TODO: receive packet into buffer
-        let result = f(&self.0);
-        println!("rx called");
-        result
-    }
-}
-
-struct StmPhyTxToken<'a>(&'a mut [u8]);
-
-impl<'a> phy::TxToken for StmPhyTxToken<'a> {
-    fn consume<R, F>(self, len: usize, f: F) -> R
-        where F: FnOnce(&mut [u8]) -> R
-    {
-        let result = f(&mut self.0[..len]);
-        println!("tx called {}", len);
-        // TODO: send packet out
-        result
-    }
-}
-```
-"##
-)]
-
-use crate::time::Instant;
 
 #[cfg(all(
     any(feature = "phy-raw_socket", feature = "phy-tuntap_interface"),
@@ -135,287 +126,3 @@ pub use self::tuntap_interface::TunTapInterface;
 /// The IPV4 payload fragment size must be an increment of this value.
 #[cfg(feature = "proto-ipv4-fragmentation")]
 pub const IPV4_FRAGMENT_PAYLOAD_ALIGNMENT: usize = 8;
-
-#[cfg(feature = "packetmeta-timestamp")]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
-struct Timestamp {
-    pub seconds: u32,
-    pub quarter_nanos: u32,
-}
-
-/// Metadata associated to a packet.
-///
-/// The packet metadata is a set of attributes associated to network packets
-/// as they travel up or down the stack. The metadata is get/set by the
-/// [`Device`] implementations or by the user when sending/receiving packets from a
-/// socket.
-///
-/// Metadata fields are enabled via Cargo features. If no field is enabled, this
-/// struct becomes zero-sized, which allows the compiler to optimize it out as if
-/// the packet metadata mechanism didn't exist at all.
-///
-/// Currently only UDP sockets allow setting/retrieving packet metadata. The metadata
-/// for packets emitted with other sockets will be all default values.
-///
-/// This struct is marked as `#[non_exhaustive]`. This means it is not possible to
-/// create it directly by specifying all fields. You have to instead create it with
-/// default values and then set the fields you want. This makes adding metadata
-/// fields a non-breaking change.
-///
-/// ```rust
-/// let mut meta = xarxa::phy::PacketMeta::default();
-/// #[cfg(feature = "packetmeta-id")]
-/// {
-///     meta.id = 15;
-/// }
-/// ```
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
-#[non_exhaustive]
-pub struct PacketMeta {
-    #[cfg(feature = "packetmeta-id")]
-    pub id: u32,
-    #[cfg(feature = "packetmeta-timestamp")]
-    pub timestamp: Timestamp,
-}
-
-/// A description of checksum behavior for a particular protocol.
-#[derive(Debug, Clone, Copy, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Checksum {
-    /// Verify checksum when receiving and compute checksum when sending.
-    #[default]
-    Both,
-    /// Verify checksum when receiving.
-    Rx,
-    /// Compute checksum before sending.
-    Tx,
-    /// Ignore checksum completely.
-    None,
-}
-
-impl Checksum {
-    /// Returns whether checksum should be verified when receiving.
-    pub fn rx(&self) -> bool {
-        match *self {
-            Checksum::Both | Checksum::Rx => true,
-            _ => false,
-        }
-    }
-
-    /// Returns whether checksum should be verified when sending.
-    pub fn tx(&self) -> bool {
-        match *self {
-            Checksum::Both | Checksum::Tx => true,
-            _ => false,
-        }
-    }
-}
-
-/// A description of checksum behavior for every supported protocol.
-#[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct ChecksumCapabilities {
-    pub ipv4: Checksum,
-    pub udp: Checksum,
-    pub tcp: Checksum,
-    #[cfg(feature = "proto-ipv4")]
-    pub icmpv4: Checksum,
-    #[cfg(feature = "proto-ipv6")]
-    pub icmpv6: Checksum,
-}
-
-impl ChecksumCapabilities {
-    /// Checksum behavior that results in not computing or verifying checksums
-    /// for any of the supported protocols.
-    pub fn ignored() -> Self {
-        ChecksumCapabilities {
-            ipv4: Checksum::None,
-            udp: Checksum::None,
-            tcp: Checksum::None,
-            #[cfg(feature = "proto-ipv4")]
-            icmpv4: Checksum::None,
-            #[cfg(feature = "proto-ipv6")]
-            icmpv6: Checksum::None,
-        }
-    }
-}
-
-/// A description of device capabilities.
-///
-/// Higher-level protocols may achieve higher throughput or lower latency if they consider
-/// the bandwidth or packet size limitations.
-#[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct DeviceCapabilities {
-    /// Medium of the device.
-    ///
-    /// This indicates what kind of packet the sent/received bytes are, and determines
-    /// some behaviors of Interface. For example, ARP/NDISC address resolution is only done
-    /// for Ethernet mediums.
-    pub medium: Medium,
-
-    /// Maximum transmission unit.
-    ///
-    /// The network device is unable to send or receive frames larger than the value returned
-    /// by this function.
-    ///
-    /// For Ethernet devices, this is the maximum Ethernet frame size, including the Ethernet header (14 octets), but
-    /// *not* including the Ethernet FCS (4 octets). Therefore, Ethernet MTU = IP MTU + 14.
-    ///
-    /// Note that in Linux and other OSes, "MTU" is the IP MTU, not the Ethernet MTU, even for Ethernet
-    /// devices. This is a common source of confusion.
-    ///
-    /// Most common IP MTU is 1500. Minimum is 576 (for IPv4) or 1280 (for IPv6). Maximum is 9216 octets.
-    pub max_transmission_unit: usize,
-
-    /// Maximum burst size, in terms of MTU.
-    ///
-    /// The network device is unable to send or receive bursts large than the value returned
-    /// by this function.
-    ///
-    /// If `None`, there is no fixed limit on burst size, e.g. if network buffers are
-    /// dynamically allocated.
-    pub max_burst_size: Option<usize>,
-
-    /// Checksum behavior.
-    ///
-    /// If the network device is capable of verifying or computing checksums for some protocols,
-    /// it can request that the stack not do so in software to improve performance.
-    pub checksum: ChecksumCapabilities,
-}
-
-impl DeviceCapabilities {
-    pub fn ip_mtu(&self) -> usize {
-        match self.medium {
-            #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => {
-                self.max_transmission_unit - crate::wire::EthernetFrame::<&[u8]>::header_len()
-            }
-            #[cfg(feature = "medium-ip")]
-            Medium::Ip => self.max_transmission_unit,
-            #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => self.max_transmission_unit, // TODO(thvdveld): what is the MTU for Medium::IEEE802
-        }
-    }
-
-    /// Special case method to determine the maximum payload size that is based on the MTU and also aligned per spec.
-    #[cfg(feature = "proto-ipv4-fragmentation")]
-    pub fn max_ipv4_fragment_size(&self, ip_header_len: usize) -> usize {
-        let payload_mtu = self.ip_mtu() - ip_header_len;
-        payload_mtu - (payload_mtu % IPV4_FRAGMENT_PAYLOAD_ALIGNMENT)
-    }
-}
-
-/// Type of medium of a device.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Medium {
-    /// Ethernet medium. Devices of this type send and receive Ethernet frames,
-    /// and interfaces using it must do neighbor discovery via ARP or NDISC.
-    ///
-    /// Examples of devices of this type are Ethernet, WiFi (802.11), Linux `tap`, and VPNs in tap (layer 2) mode.
-    #[cfg(feature = "medium-ethernet")]
-    Ethernet,
-
-    /// IP medium. Devices of this type send and receive IP frames, without an
-    /// Ethernet header. MAC addresses are not used, and no neighbor discovery (ARP, NDISC) is done.
-    ///
-    /// Examples of devices of this type are the Linux `tun`, PPP interfaces, VPNs in tun (layer 3) mode.
-    #[cfg(feature = "medium-ip")]
-    Ip,
-
-    #[cfg(feature = "medium-ieee802154")]
-    Ieee802154,
-}
-
-impl Default for Medium {
-    fn default() -> Medium {
-        #[cfg(feature = "medium-ethernet")]
-        return Medium::Ethernet;
-        #[cfg(all(feature = "medium-ip", not(feature = "medium-ethernet")))]
-        return Medium::Ip;
-        #[cfg(all(
-            feature = "medium-ieee802154",
-            not(feature = "medium-ip"),
-            not(feature = "medium-ethernet")
-        ))]
-        return Medium::Ieee802154;
-        #[cfg(all(
-            not(feature = "medium-ip"),
-            not(feature = "medium-ethernet"),
-            not(feature = "medium-ieee802154")
-        ))]
-        return panic!("No medium enabled");
-    }
-}
-
-/// An interface for sending and receiving raw network frames.
-///
-/// The interface is based on _tokens_, which are types that allow to receive/transmit a
-/// single packet. The `receive` and `transmit` functions only construct such tokens, the
-/// real sending/receiving operation are performed when the tokens are consumed.
-pub trait Device {
-    type RxToken<'a>: RxToken
-    where
-        Self: 'a;
-    type TxToken<'a>: TxToken
-    where
-        Self: 'a;
-
-    /// Construct a token pair consisting of one receive token and one transmit token.
-    ///
-    /// The additional transmit token makes it possible to generate a reply packet based
-    /// on the contents of the received packet. For example, this makes it possible to
-    /// handle arbitrarily large ICMP echo ("ping") requests, where the all received bytes
-    /// need to be sent back, without heap allocation.
-    ///
-    /// The timestamp must be a number of milliseconds, monotonically increasing since an
-    /// arbitrary moment in time, such as system startup.
-    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)>;
-
-    /// Construct a transmit token.
-    ///
-    /// The timestamp must be a number of milliseconds, monotonically increasing since an
-    /// arbitrary moment in time, such as system startup.
-    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>>;
-
-    /// Get a description of device capabilities.
-    fn capabilities(&self) -> DeviceCapabilities;
-}
-
-/// A token to receive a single network packet.
-pub trait RxToken {
-    /// Consumes the token to receive a single network packet.
-    ///
-    /// This method receives a packet and then calls the given closure `f` with the raw
-    /// packet bytes as argument.
-    fn consume<R, F>(self, f: F) -> R
-    where
-        F: FnOnce(&[u8]) -> R;
-
-    /// The Packet ID associated with the frame received by this [`RxToken`]
-    fn meta(&self) -> PacketMeta {
-        PacketMeta::default()
-    }
-}
-
-/// A token to transmit a single network packet.
-pub trait TxToken {
-    /// Consumes the token to send a single network packet.
-    ///
-    /// This method constructs a transmit buffer of size `len` and calls the passed
-    /// closure `f` with a mutable reference to that buffer. The closure should construct
-    /// a valid network packet (e.g. an ethernet packet) in the buffer. When the closure
-    /// returns, the transmit buffer is sent out.
-    fn consume<R, F>(self, len: usize, f: F) -> R
-    where
-        F: FnOnce(&mut [u8]) -> R;
-
-    /// The Packet ID to be associated with the frame to be transmitted by this [`TxToken`].
-    #[allow(unused_variables)]
-    fn set_meta(&mut self, meta: PacketMeta) {}
-}

--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -1,6 +1,6 @@
 use byteorder::{ByteOrder, NativeEndian};
 use core::cell::RefCell;
-use phy::Medium;
+use phy::DriverMedium;
 #[cfg(feature = "std")]
 use std::io::Write;
 
@@ -119,25 +119,31 @@ where
     lower: D,
     sink: RefCell<S>,
     mode: PcapMode,
+    clock: fn() -> Instant,
 }
 
 impl<D: Device, S: PcapSink> PcapWriter<D, S> {
     /// Creates a packet capture writer.
-    pub fn new(lower: D, mut sink: S, mode: PcapMode) -> PcapWriter<D, S> {
+    ///
+    /// `clock` is used to timestamp the captured packets. Under `std`, [`Instant::now`]
+    /// is a suitable value.
+    pub fn new(lower: D, mut sink: S, mode: PcapMode, clock: fn() -> Instant) -> PcapWriter<D, S> {
         let medium = lower.capabilities().medium;
         let link_type = match medium {
             #[cfg(feature = "medium-ip")]
-            Medium::Ip => PcapLinkType::Ip,
+            DriverMedium::Ip => PcapLinkType::Ip,
             #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => PcapLinkType::Ethernet,
+            DriverMedium::Ethernet => PcapLinkType::Ethernet,
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => PcapLinkType::Ieee802154WithoutFcs,
+            DriverMedium::Ieee802154 => PcapLinkType::Ieee802154WithoutFcs,
+            medium => panic!("unsupported medium {medium:?}"),
         };
         sink.global_header(link_type);
         PcapWriter {
             lower,
             sink: RefCell::new(sink),
             mode,
+            clock,
         }
     }
 
@@ -174,36 +180,36 @@ where
         self.lower.capabilities()
     }
 
-    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let sink = &self.sink;
         let mode = self.mode;
-        self.lower
-            .receive(timestamp)
-            .map(move |(rx_token, tx_token)| {
-                let rx = RxToken {
-                    token: rx_token,
-                    sink,
-                    mode,
-                    timestamp,
-                };
-                let tx = TxToken {
-                    token: tx_token,
-                    sink,
-                    mode,
-                    timestamp,
-                };
-                (rx, tx)
-            })
+        let clock = self.clock;
+        self.lower.receive().map(move |(rx_token, tx_token)| {
+            let rx = RxToken {
+                token: rx_token,
+                sink,
+                mode,
+                clock,
+            };
+            let tx = TxToken {
+                token: tx_token,
+                sink,
+                mode,
+                clock,
+            };
+            (rx, tx)
+        })
     }
 
-    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         let sink = &self.sink;
         let mode = self.mode;
-        self.lower.transmit(timestamp).map(move |token| TxToken {
+        let clock = self.clock;
+        self.lower.transmit().map(move |token| TxToken {
             token,
             sink,
             mode,
-            timestamp,
+            clock,
         })
     }
 }
@@ -213,7 +219,7 @@ pub struct RxToken<'a, Rx: phy::RxToken, S: PcapSink> {
     token: Rx,
     sink: &'a RefCell<S>,
     mode: PcapMode,
-    timestamp: Instant,
+    clock: fn() -> Instant,
 }
 
 impl<'a, Rx: phy::RxToken, S: PcapSink> phy::RxToken for RxToken<'a, Rx, S> {
@@ -223,7 +229,7 @@ impl<'a, Rx: phy::RxToken, S: PcapSink> phy::RxToken for RxToken<'a, Rx, S> {
                 PcapMode::Both | PcapMode::RxOnly => self
                     .sink
                     .borrow_mut()
-                    .packet(self.timestamp, buffer.as_ref()),
+                    .packet((self.clock)(), buffer.as_ref()),
                 PcapMode::TxOnly => (),
             }
             f(buffer)
@@ -240,7 +246,7 @@ pub struct TxToken<'a, Tx: phy::TxToken, S: PcapSink> {
     token: Tx,
     sink: &'a RefCell<S>,
     mode: PcapMode,
-    timestamp: Instant,
+    clock: fn() -> Instant,
 }
 
 impl<'a, Tx: phy::TxToken, S: PcapSink> phy::TxToken for TxToken<'a, Tx, S> {
@@ -252,7 +258,7 @@ impl<'a, Tx: phy::TxToken, S: PcapSink> phy::TxToken for TxToken<'a, Tx, S> {
             let result = f(buffer);
             match self.mode {
                 PcapMode::Both | PcapMode::TxOnly => {
-                    self.sink.borrow_mut().packet(self.timestamp, buffer)
+                    self.sink.borrow_mut().packet((self.clock)(), buffer)
                 }
                 PcapMode::RxOnly => (),
             };

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -4,13 +4,12 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::Rc;
 use std::vec::Vec;
 
-use crate::phy::{self, Device, DeviceCapabilities, Medium, sys};
-use crate::time::Instant;
+use crate::phy::{self, Device, DeviceCapabilities, DriverMedium, sys};
 
 /// A socket that captures or transmits the complete frame.
 #[derive(Debug)]
 pub struct RawSocket {
-    medium: Medium,
+    medium: DriverMedium,
     lower: Rc<RefCell<sys::RawSocketDesc>>,
     mtu: usize,
 }
@@ -26,14 +25,14 @@ impl RawSocket {
     ///
     /// This requires superuser privileges or a corresponding capability bit
     /// set on the executable.
-    pub fn new(name: &str, medium: Medium) -> io::Result<RawSocket> {
+    pub fn new(name: &str, medium: DriverMedium) -> io::Result<RawSocket> {
         let mut lower = sys::RawSocketDesc::new(name, medium)?;
         lower.bind_interface()?;
 
         let mut mtu = lower.interface_mtu()?;
 
         #[cfg(feature = "medium-ieee802154")]
-        if medium == Medium::Ieee802154 {
+        if medium == DriverMedium::Ieee802154 {
             // SIOCGIFMTU returns 127 - (ACK_PSDU - FCS - 1) - FCS.
             //                    127 - (5 - 2 - 1) - 2 = 123
             // For IEEE802154, we want to add (ACK_PSDU - FCS - 1), since that is what SIOCGIFMTU
@@ -44,7 +43,7 @@ impl RawSocket {
         }
 
         #[cfg(feature = "medium-ethernet")]
-        if medium == Medium::Ethernet {
+        if medium == DriverMedium::Ethernet {
             // SIOCGIFMTU returns the IP MTU (typically 1500 bytes.)
             // xarxa counts the entire Ethernet packet in the MTU, so add the Ethernet header size to it.
             mtu += crate::wire::EthernetFrame::<&[u8]>::header_len()
@@ -69,14 +68,13 @@ impl Device for RawSocket {
         Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
-        DeviceCapabilities {
-            max_transmission_unit: self.mtu,
-            medium: self.medium,
-            ..DeviceCapabilities::default()
-        }
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = self.mtu;
+        caps.medium = self.medium;
+        caps
     }
 
-    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -93,7 +91,7 @@ impl Device for RawSocket {
         }
     }
 
-    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })

--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -5,7 +5,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use libc;
 
 use super::{ifreq, ifreq_for};
-use crate::phy::Medium;
+use crate::phy::DriverMedium;
 use crate::wire::ETHERNET_HEADER_LEN;
 
 /// set interface
@@ -97,7 +97,7 @@ fn open_device() -> io::Result<libc::c_int> {
 }
 
 impl BpfDevice {
-    pub fn new(name: &str, _medium: Medium) -> io::Result<BpfDevice> {
+    pub fn new(name: &str, _medium: DriverMedium) -> io::Result<BpfDevice> {
         Ok(BpfDevice {
             fd: open_device()?,
             ifreq: ifreq_for(name),

--- a/src/phy/sys/raw_socket.rs
+++ b/src/phy/sys/raw_socket.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::phy::Medium;
+use crate::phy::DriverMedium;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::{io, mem};
 
@@ -17,14 +17,15 @@ impl AsRawFd for RawSocketDesc {
 }
 
 impl RawSocketDesc {
-    pub fn new(name: &str, medium: Medium) -> io::Result<RawSocketDesc> {
+    pub fn new(name: &str, medium: DriverMedium) -> io::Result<RawSocketDesc> {
         let protocol = match medium {
             #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => imp::ETH_P_ALL,
+            DriverMedium::Ethernet => imp::ETH_P_ALL,
             #[cfg(feature = "medium-ip")]
-            Medium::Ip => imp::ETH_P_ALL,
+            DriverMedium::Ip => imp::ETH_P_ALL,
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => imp::ETH_P_IEEE802154,
+            DriverMedium::Ieee802154 => imp::ETH_P_IEEE802154,
+            medium => panic!("unsupported medium {medium:?}"),
         };
 
         let lower = unsafe {

--- a/src/phy/sys/tuntap_interface.rs
+++ b/src/phy/sys/tuntap_interface.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::phy::Medium;
+use crate::phy::DriverMedium;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 
@@ -16,7 +16,7 @@ impl AsRawFd for TunTapInterfaceDesc {
 }
 
 impl TunTapInterfaceDesc {
-    pub fn new(name: &str, medium: Medium) -> io::Result<TunTapInterfaceDesc> {
+    pub fn new(name: &str, medium: DriverMedium) -> io::Result<TunTapInterfaceDesc> {
         let lower = unsafe {
             let lower = libc::open(c"/dev/net/tun".as_ptr(), libc::O_RDWR | libc::O_NONBLOCK);
             if lower == -1 {
@@ -38,22 +38,23 @@ impl TunTapInterfaceDesc {
 
     fn attach_interface_ifreq(
         lower: libc::c_int,
-        medium: Medium,
+        medium: DriverMedium,
         ifr: &mut ifreq,
     ) -> io::Result<()> {
         let mode = match medium {
             #[cfg(feature = "medium-ip")]
-            Medium::Ip => imp::IFF_TUN,
+            DriverMedium::Ip => imp::IFF_TUN,
             #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => imp::IFF_TAP,
+            DriverMedium::Ethernet => imp::IFF_TAP,
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => todo!(),
+            DriverMedium::Ieee802154 => todo!(),
+            medium => panic!("unsupported medium {medium:?}"),
         };
         ifr.ifr_data = mode | imp::IFF_NO_PI;
         ifreq_ioctl(lower, ifr, imp::TUNSETIFF).map(|_| ())
     }
 
-    fn mtu_ifreq(medium: Medium, ifr: &mut ifreq) -> io::Result<usize> {
+    fn mtu_ifreq(medium: DriverMedium, ifr: &mut ifreq) -> io::Result<usize> {
         let lower = unsafe {
             let lower = libc::socket(libc::AF_INET, libc::SOCK_DGRAM, libc::IPPROTO_IP);
             if lower == -1 {
@@ -75,11 +76,12 @@ impl TunTapInterfaceDesc {
         // xarxa counts the entire Ethernet packet in the MTU, so add the Ethernet header size to it.
         let mtu = match medium {
             #[cfg(feature = "medium-ip")]
-            Medium::Ip => ip_mtu,
+            DriverMedium::Ip => ip_mtu,
             #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => ip_mtu + crate::wire::EthernetFrame::<&[u8]>::header_len(),
+            DriverMedium::Ethernet => ip_mtu + crate::wire::EthernetFrame::<&[u8]>::header_len(),
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => todo!(),
+            DriverMedium::Ieee802154 => todo!(),
+            medium => panic!("unsupported medium {medium:?}"),
         };
 
         Ok(mtu)

--- a/src/phy/tracer.rs
+++ b/src/phy/tracer.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 
-use crate::phy::{self, Device, DeviceCapabilities, Medium};
-use crate::time::Instant;
+use crate::phy::{self, Device, DeviceCapabilities, DriverMedium};
 use crate::wire::pretty_print::{PrettyIndent, PrettyPrint};
 
 /// A tracer device.
@@ -11,12 +10,12 @@ use crate::wire::pretty_print::{PrettyIndent, PrettyPrint};
 /// device.
 pub struct Tracer<D: Device> {
     inner: D,
-    writer: fn(Instant, TracerPacket),
+    writer: fn(TracerPacket),
 }
 
 impl<D: Device> Tracer<D> {
     /// Create a tracer device.
-    pub fn new(inner: D, writer: fn(timestamp: Instant, packet: TracerPacket)) -> Tracer<D> {
+    pub fn new(inner: D, writer: fn(packet: TracerPacket)) -> Tracer<D> {
         Tracer { inner, writer }
     }
 
@@ -55,32 +54,29 @@ impl<D: Device> Device for Tracer<D> {
         self.inner.capabilities()
     }
 
-    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let medium = self.inner.capabilities().medium;
-        self.inner.receive(timestamp).map(|(rx_token, tx_token)| {
+        self.inner.receive().map(|(rx_token, tx_token)| {
             let rx = RxToken {
                 token: rx_token,
                 writer: self.writer,
                 medium,
-                timestamp,
             };
             let tx = TxToken {
                 token: tx_token,
                 writer: self.writer,
                 medium,
-                timestamp,
             };
             (rx, tx)
         })
     }
 
-    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         let medium = self.inner.capabilities().medium;
-        self.inner.transmit(timestamp).map(|tx_token| TxToken {
+        self.inner.transmit().map(|tx_token| TxToken {
             token: tx_token,
             medium,
             writer: self.writer,
-            timestamp,
         })
     }
 }
@@ -88,9 +84,8 @@ impl<D: Device> Device for Tracer<D> {
 #[doc(hidden)]
 pub struct RxToken<Rx: phy::RxToken> {
     token: Rx,
-    writer: fn(Instant, TracerPacket),
-    medium: Medium,
-    timestamp: Instant,
+    writer: fn(TracerPacket),
+    medium: DriverMedium,
 }
 
 impl<Rx: phy::RxToken> phy::RxToken for RxToken<Rx> {
@@ -99,14 +94,11 @@ impl<Rx: phy::RxToken> phy::RxToken for RxToken<Rx> {
         F: FnOnce(&[u8]) -> R,
     {
         self.token.consume(|buffer| {
-            (self.writer)(
-                self.timestamp,
-                TracerPacket {
-                    buffer,
-                    medium: self.medium,
-                    direction: TracerDirection::RX,
-                },
-            );
+            (self.writer)(TracerPacket {
+                buffer,
+                medium: self.medium,
+                direction: TracerDirection::RX,
+            });
             f(buffer)
         })
     }
@@ -119,9 +111,8 @@ impl<Rx: phy::RxToken> phy::RxToken for RxToken<Rx> {
 #[doc(hidden)]
 pub struct TxToken<Tx: phy::TxToken> {
     token: Tx,
-    writer: fn(Instant, TracerPacket),
-    medium: Medium,
-    timestamp: Instant,
+    writer: fn(TracerPacket),
+    medium: DriverMedium,
 }
 
 impl<Tx: phy::TxToken> phy::TxToken for TxToken<Tx> {
@@ -131,14 +122,11 @@ impl<Tx: phy::TxToken> phy::TxToken for TxToken<Tx> {
     {
         self.token.consume(len, |buffer| {
             let result = f(buffer);
-            (self.writer)(
-                self.timestamp,
-                TracerPacket {
-                    buffer,
-                    medium: self.medium,
-                    direction: TracerDirection::TX,
-                },
-            );
+            (self.writer)(TracerPacket {
+                buffer,
+                medium: self.medium,
+                direction: TracerDirection::TX,
+            });
             result
         })
     }
@@ -154,7 +142,7 @@ pub struct TracerPacket<'a> {
     /// Packet buffer
     pub buffer: &'a [u8],
     /// Packet medium
-    pub medium: Medium,
+    pub medium: DriverMedium,
     /// Direction in which packet is being traced
     pub direction: TracerDirection,
 }
@@ -178,13 +166,13 @@ impl<'a> fmt::Display for TracerPacket<'a> {
         let mut indent = PrettyIndent::new(prefix);
         match self.medium {
             #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => crate::wire::EthernetFrame::<&'static [u8]>::pretty_print(
+            DriverMedium::Ethernet => crate::wire::EthernetFrame::<&'static [u8]>::pretty_print(
                 &self.buffer,
                 f,
                 &mut indent,
             ),
             #[cfg(feature = "medium-ip")]
-            Medium::Ip => match crate::wire::IpVersion::of_packet(self.buffer) {
+            DriverMedium::Ip => match crate::wire::IpVersion::of_packet(self.buffer) {
                 #[cfg(feature = "proto-ipv4")]
                 Ok(crate::wire::IpVersion::Ipv4) => {
                     crate::wire::Ipv4Packet::<&'static [u8]>::pretty_print(
@@ -204,7 +192,8 @@ impl<'a> fmt::Display for TracerPacket<'a> {
                 _ => f.write_str("unrecognized IP version"),
             },
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => Ok(()), // XXX
+            DriverMedium::Ieee802154 => Ok(()), // XXX
+            _ => f.write_str("unrecognized medium"),
         }
     }
 }
@@ -217,10 +206,7 @@ mod tests {
     use super::*;
 
     use crate::phy::ChecksumCapabilities;
-    use crate::{
-        phy::{Device, Loopback, RxToken, TxToken},
-        time::Instant,
-    };
+    use crate::phy::{Device, Loopback, RxToken, TxToken};
 
     #[cfg(any(
         feature = "medium-ethernet",
@@ -229,30 +215,24 @@ mod tests {
     ))]
     #[test]
     fn test_tracer() {
-        type TracerEvent = (Instant, Vec<u8>, Medium, TracerDirection);
+        type TracerEvent = (Vec<u8>, DriverMedium, TracerDirection);
         thread_local! {
             static TRACE_EVENTS: RefCell<VecDeque<TracerEvent>> = const { RefCell::new(VecDeque::new()) };
         }
         TRACE_EVENTS.replace(VecDeque::new());
 
-        let medium = Medium::default();
+        let medium = DriverMedium::default();
 
         let loopback_device = Loopback::new(medium);
-        let mut tracer_device = Tracer::new(loopback_device, |instant, packet| {
+        let mut tracer_device = Tracer::new(loopback_device, |packet| {
             TRACE_EVENTS.with_borrow_mut(|events| {
-                events.push_back((
-                    instant,
-                    packet.buffer.to_owned(),
-                    packet.medium,
-                    packet.direction,
-                ))
+                events.push_back((packet.buffer.to_owned(), packet.medium, packet.direction))
             });
         });
 
         let expected_payload = [1, 2, 3, 4, 5, 6, 7, 8];
 
-        let tx_instant = Instant::from_secs(1);
-        let tx_token = tracer_device.transmit(tx_instant).unwrap();
+        let tx_token = tracer_device.transmit().unwrap();
 
         tx_token.consume(expected_payload.len(), |buf| {
             buf.copy_from_slice(&expected_payload)
@@ -260,18 +240,12 @@ mod tests {
         let last_event = TRACE_EVENTS.with_borrow_mut(|events| events.pop_front());
         assert_eq!(
             last_event,
-            Some((
-                tx_instant,
-                expected_payload.into(),
-                medium,
-                TracerDirection::TX
-            ))
+            Some((expected_payload.into(), medium, TracerDirection::TX))
         );
         let last_event = TRACE_EVENTS.with_borrow_mut(|events| events.pop_front());
         assert_eq!(last_event, None);
 
-        let rx_instant = Instant::from_secs(2);
-        let (rx_token, _) = tracer_device.receive(rx_instant).unwrap();
+        let (rx_token, _) = tracer_device.receive().unwrap();
         let mut rx_pkt = [0; 8];
         rx_token.consume(|buf| rx_pkt.copy_from_slice(buf));
 
@@ -280,12 +254,7 @@ mod tests {
         let last_event = TRACE_EVENTS.with_borrow_mut(|events| events.pop_front());
         assert_eq!(
             last_event,
-            Some((
-                rx_instant,
-                expected_payload.into(),
-                medium,
-                TracerDirection::RX
-            ))
+            Some((expected_payload.into(), medium, TracerDirection::RX))
         );
         let last_event = TRACE_EVENTS.with_borrow_mut(|events| events.pop_front());
         assert_eq!(last_event, None);
@@ -311,7 +280,7 @@ mod tests {
 
         let pkt = TracerPacket {
             buffer: &buffer,
-            medium: Medium::Ethernet,
+            medium: DriverMedium::Ethernet,
             direction: TracerDirection::RX,
         };
 
@@ -345,7 +314,7 @@ mod tests {
 
         let pkt = TracerPacket {
             buffer: &buffer,
-            medium: Medium::Ip,
+            medium: DriverMedium::Ip,
             direction: TracerDirection::TX,
         };
 

--- a/src/phy/tuntap_interface.rs
+++ b/src/phy/tuntap_interface.rs
@@ -4,15 +4,14 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::Rc;
 use std::vec::Vec;
 
-use crate::phy::{self, Device, DeviceCapabilities, Medium, sys};
-use crate::time::Instant;
+use crate::phy::{self, Device, DeviceCapabilities, DriverMedium, sys};
 
 /// A virtual TUN (IP) or TAP (Ethernet) interface.
 #[derive(Debug)]
 pub struct TunTapInterface {
     lower: Rc<RefCell<sys::TunTapInterfaceDesc>>,
     mtu: usize,
-    medium: Medium,
+    medium: DriverMedium,
 }
 
 impl AsRawFd for TunTapInterface {
@@ -27,7 +26,7 @@ impl TunTapInterface {
     /// If `name` is a persistent interface configured with UID of the current user,
     /// no special privileges are needed. Otherwise, this requires superuser privileges
     /// or a corresponding capability set on the executable.
-    pub fn new(name: &str, medium: Medium) -> io::Result<TunTapInterface> {
+    pub fn new(name: &str, medium: DriverMedium) -> io::Result<TunTapInterface> {
         let lower = sys::TunTapInterfaceDesc::new(name, medium)?;
         let mtu = lower.interface_mtu()?;
         Ok(TunTapInterface {
@@ -41,7 +40,7 @@ impl TunTapInterface {
     ///
     /// On platforms like Android, a file descriptor to a tun interface is exposed.
     /// On these platforms, a TunTapInterface cannot be instantiated with a name.
-    pub fn from_fd(fd: RawFd, medium: Medium, mtu: usize) -> io::Result<TunTapInterface> {
+    pub fn from_fd(fd: RawFd, medium: DriverMedium, mtu: usize) -> io::Result<TunTapInterface> {
         let lower = sys::TunTapInterfaceDesc::from_fd(fd, mtu)?;
         Ok(TunTapInterface {
             lower: Rc::new(RefCell::new(lower)),
@@ -56,14 +55,13 @@ impl Device for TunTapInterface {
     type TxToken<'a> = TxToken;
 
     fn capabilities(&self) -> DeviceCapabilities {
-        DeviceCapabilities {
-            max_transmission_unit: self.mtu,
-            medium: self.medium,
-            ..DeviceCapabilities::default()
-        }
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = self.mtu;
+        caps.medium = self.medium;
+        caps
     }
 
-    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -80,7 +78,7 @@ impl Device for TunTapInterface {
         }
     }
 
-    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -68,6 +68,11 @@ impl TestingDevice {
     ///
     /// Every packet transmitted through this device will be received through it
     /// in FIFO order.
+    /// The medium of this device.
+    pub(crate) fn medium(&self) -> Medium {
+        self.medium
+    }
+
     pub fn new(medium: Medium) -> Self {
         TestingDevice {
             tx_queue: VecDeque::new(),
@@ -90,14 +95,13 @@ impl Device for TestingDevice {
     type TxToken<'a> = TxToken<'a>;
 
     fn capabilities(&self) -> DeviceCapabilities {
-        DeviceCapabilities {
-            medium: self.medium,
-            max_transmission_unit: self.max_transmission_unit,
-            ..DeviceCapabilities::default()
-        }
+        let mut caps = DeviceCapabilities::default();
+        caps.medium = self.medium.to_driver();
+        caps.max_transmission_unit = self.max_transmission_unit;
+        caps
     }
 
-    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         self.rx_queue.pop_front().map(move |buffer| {
             let rx = RxToken { buffer };
             let tx = TxToken {
@@ -107,7 +111,7 @@ impl Device for TestingDevice {
         })
     }
 
-    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             queue: &mut self.tx_queue,
         })

--- a/tests/netsim.rs
+++ b/tests/netsim.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::BinaryHeap;
 use std::fmt::Write as _;
 use std::io::Write as _;
@@ -9,7 +9,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use xarxa::iface::{Config, Interface, SocketHandle, SocketSet};
 use xarxa::phy::Tracer;
-use xarxa::phy::{self, ChecksumCapabilities, Device, DeviceCapabilities, Medium};
+use xarxa::phy::{self, ChecksumCapabilities, Device, DeviceCapabilities, DriverMedium};
 use xarxa::socket::tcp;
 use xarxa::time::{Duration, Instant};
 use xarxa::wire::{EthernetAddress, HardwareAddress, IpAddress, IpCidr};
@@ -199,6 +199,8 @@ fn run_test(case: TestSpec) -> TestResult {
     assert!(case.flows.len() < 256, "too many flows");
 
     let mut time = Instant::ZERO;
+    // The simulation clock, shared with every `QueueDevice`.
+    let now = Rc::new(Cell::new(time));
 
     let bottleneck_a_to_b = Rc::new(RefCell::new(Bottleneck::new(case.bandwidth, case.capacity)));
     let bottleneck_b_to_a = Rc::new(RefCell::new(Bottleneck::new(case.bandwidth, case.capacity)));
@@ -234,19 +236,19 @@ fn run_test(case: TestSpec) -> TestResult {
             Rc::clone(&bottleneck_a_to_b),
             Rc::clone(&wire_a_to_b),
             Rc::clone(&wire_b_to_a),
-            Medium::Ethernet,
+            DriverMedium::Ethernet,
+            Rc::clone(&now),
         );
         let device_b = QueueDevice::new(
             Rc::clone(&bottleneck_b_to_a),
             Rc::clone(&wire_b_to_a),
             Rc::clone(&wire_a_to_b),
-            Medium::Ethernet,
+            DriverMedium::Ethernet,
+            Rc::clone(&now),
         );
 
-        let mut device_a =
-            Tracer::new(device_a, |_timestamp, _printer| log::trace!("{}", _printer));
-        let mut device_b =
-            Tracer::new(device_b, |_timestamp, _printer| log::trace!("{}", _printer));
+        let mut device_a = Tracer::new(device_a, |_printer| log::trace!("{}", _printer));
+        let mut device_b = Tracer::new(device_b, |_printer| log::trace!("{}", _printer));
 
         let mut iface_a = Interface::new(Config::new(mac_a), &mut device_a, time);
         iface_a.update_ip_addrs(|a| a.push(IpCidr::new(ip_a, 24)).unwrap());
@@ -292,6 +294,7 @@ fn run_test(case: TestSpec) -> TestResult {
     }
 
     while flows.iter().any(|f| f.received < f.target) {
+        now.set(time);
         *CLOCK.lock().unwrap() = (time, ' ');
         log::info!("loop");
 
@@ -344,6 +347,7 @@ fn run_test(case: TestSpec) -> TestResult {
             .expect("no pending event");
 
         time = time.max(next_time);
+        now.set(time);
     }
 
     let duration_secs = duration_to_secs(time - Instant::ZERO);
@@ -517,7 +521,9 @@ struct QueueDevice {
     bottleneck: Rc<RefCell<Bottleneck>>,
     tx_wire: Rc<RefCell<Wire>>,
     rx_wire: Rc<RefCell<Wire>>,
-    medium: Medium,
+    medium: DriverMedium,
+    /// The simulation clock, shared with the test loop.
+    now: Rc<Cell<Instant>>,
 }
 
 impl QueueDevice {
@@ -525,13 +531,15 @@ impl QueueDevice {
         bottleneck: Rc<RefCell<Bottleneck>>,
         tx_wire: Rc<RefCell<Wire>>,
         rx_wire: Rc<RefCell<Wire>>,
-        medium: Medium,
+        medium: DriverMedium,
+        now: Rc<Cell<Instant>>,
     ) -> Self {
         Self {
             bottleneck,
             tx_wire,
             rx_wire,
             medium,
+            now,
         }
     }
 }
@@ -554,7 +562,8 @@ impl Device for QueueDevice {
         caps
     }
 
-    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let timestamp = self.now.get();
         let mut rx = self.rx_wire.borrow_mut();
         let arrival = rx.peek_arrival()?;
         if arrival > timestamp {
@@ -572,11 +581,11 @@ impl Device for QueueDevice {
         ))
     }
 
-    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             bottleneck: &self.bottleneck,
             wire: &self.tx_wire,
-            timestamp,
+            timestamp: self.now.get(),
         })
     }
 }

--- a/xarxa-driver/Cargo.toml
+++ b/xarxa-driver/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "xarxa-driver"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.91"
+description = "Driver trait for the `xarxa` TCP/IP network stack."
+documentation = "https://docs.rs/xarxa-driver/"
+homepage = "https://github.com/embassy-rs/xarxa"
+repository = "https://github.com/embassy-rs/xarxa.git"
+readme = "README.md"
+keywords = ["ip", "tcp", "udp", "ethernet", "network"]
+categories = ["embedded", "network-programming"]
+license = "0BSD"
+
+[dependencies]
+defmt = { version = "1.0.1", optional = true }
+
+[features]
+defmt = ["dep:defmt"]
+
+# Enable the `PacketMeta::id` field.
+"packetmeta-id" = []
+# Enable the `PacketMeta::timestamp` field.
+"packetmeta-timestamp" = []

--- a/xarxa-driver/README.md
+++ b/xarxa-driver/README.md
@@ -1,0 +1,26 @@
+# xarxa-driver
+
+Device driver trait for the [`xarxa`](https://github.com/embassy-rs/xarxa) TCP/IP network stack.
+
+This crate contains only the [`Device`] trait and supporting types. It is deliberately tiny, and  is versioned independently from `xarxa` itself. 
+
+The goal is that a single major version of `xarxa-driver` can be used by many major versions of `xarxa`. This way, a new `xarxa` release instantly works with the ecosystem without 
+
+Driver crates should depend on `xarxa-driver` and implement [`Device`]. They should *not*
+depend on `xarxa`.
+
+## Stability
+
+To keep this crate stable, it deliberately does *not* contain:
+
+- Anything that varies with `xarxa`'s Cargo features. In particular, enums here always have
+  all their variants, because adding or removing an enum variant is a breaking change,
+  unlike adding a field to a `#[non_exhaustive]` struct.
+- Time types. Drivers are not given a timestamp; hardware timestamping is reported through
+  [`PacketMeta`] instead.
+- Packet parsing, addresses, or anything else from `xarxa::wire`.
+
+## License
+
+This crate is 0-clause BSD licensed, see the `LICENSE-0BSD.txt` file at the root of the
+repository.

--- a/xarxa-driver/src/lib.rs
+++ b/xarxa-driver/src/lib.rs
@@ -1,0 +1,342 @@
+#![no_std]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+/// Type of medium of a device.
+///
+/// This indicates what kind of packet the sent/received bytes are, and determines
+/// some behaviors of the interface. For example, ARP/NDISC address resolution is only
+/// done for Ethernet mediums.
+///
+/// All variants are always present, regardless of which Cargo features `xarxa` is built
+/// with. Creating an interface on a device whose medium the stack was not built for panics.
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Medium {
+    /// Ethernet medium. Devices of this type send and receive Ethernet frames,
+    /// and interfaces using it must do neighbor discovery via ARP or NDISC.
+    ///
+    /// Examples of devices of this type are Ethernet, WiFi (802.11), Linux `tap`, and VPNs in tap (layer 2) mode.
+    #[default]
+    Ethernet,
+
+    /// IP medium. Devices of this type send and receive IP frames, without an
+    /// Ethernet header. MAC addresses are not used, and no neighbor discovery (ARP, NDISC) is done.
+    ///
+    /// Examples of devices of this type are the Linux `tun`, PPP interfaces, VPNs in tun (layer 3) mode.
+    Ip,
+
+    /// IEEE 802.15.4 medium. Devices of this type send and receive IEEE 802.15.4 frames,
+    /// carrying 6LoWPAN-compressed IPv6 packets.
+    Ieee802154,
+}
+
+/// A representation of a hardware packet timestamp.
+///
+/// This is the time at which the network device saw the packet on the wire, as measured by
+/// the device's own clock. It is unrelated to the `Instant` the stack is polled with.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
+pub struct Timestamp {
+    /// Whole seconds.
+    pub seconds: u32,
+    /// Fractional part, in quarters of a nanosecond.
+    pub quarter_nanos: u32,
+}
+
+impl Timestamp {
+    /// Construct a timestamp from seconds and nanoseconds.
+    pub const fn from_seconds_and_nanos(seconds: u32, nanos: u32) -> Self {
+        Self {
+            seconds,
+            quarter_nanos: nanos << 2,
+        }
+    }
+}
+
+/// Metadata associated to a packet.
+///
+/// The packet metadata is a set of attributes associated to network packets
+/// as they travel up or down the stack. The metadata is get/set by the
+/// [`Driver`] implementations or by the user when sending/receiving packets from a
+/// socket.
+///
+/// Metadata fields are enabled via Cargo features. If no field is enabled, this
+/// struct becomes zero-sized, which allows the compiler to optimize it out as if
+/// the packet metadata mechanism didn't exist at all.
+///
+/// This struct is marked as `#[non_exhaustive]`. This means it is not possible to
+/// create it directly by specifying all fields. You have to instead create it with
+/// default values and then set the fields you want. This makes adding metadata
+/// fields a non-breaking change.
+///
+/// ```rust
+/// let mut meta = xarxa_driver::PacketMeta::default();
+/// #[cfg(feature = "packetmeta-id")]
+/// {
+///     meta.id = 15;
+/// }
+/// ```
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct PacketMeta {
+    /// An identifier associated with a transmitted or received packet.
+    #[cfg(feature = "packetmeta-id")]
+    pub id: u32,
+    /// The time at which the device saw this packet on the wire.
+    #[cfg(feature = "packetmeta-timestamp")]
+    pub timestamp: Timestamp,
+}
+
+/// A description of checksum behavior for a particular protocol.
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Checksum {
+    /// Verify checksum when receiving and compute checksum when sending.
+    #[default]
+    Both,
+    /// Verify checksum when receiving.
+    Rx,
+    /// Compute checksum before sending.
+    Tx,
+    /// Ignore checksum completely.
+    None,
+}
+
+impl Checksum {
+    /// Returns whether checksum should be verified when receiving.
+    pub fn rx(&self) -> bool {
+        matches!(*self, Checksum::Both | Checksum::Rx)
+    }
+
+    /// Returns whether checksum should be verified when sending.
+    pub fn tx(&self) -> bool {
+        matches!(*self, Checksum::Both | Checksum::Tx)
+    }
+}
+
+/// A description of checksum behavior for every supported protocol.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct ChecksumCapabilities {
+    /// Checksum behavior for IPv4.
+    pub ipv4: Checksum,
+    /// Checksum behavior for UDP.
+    pub udp: Checksum,
+    /// Checksum behavior for TCP.
+    pub tcp: Checksum,
+    /// Checksum behavior for ICMPv4.
+    pub icmpv4: Checksum,
+    /// Checksum behavior for ICMPv6.
+    pub icmpv6: Checksum,
+}
+
+impl ChecksumCapabilities {
+    /// Checksum behavior that results in not computing or verifying checksums
+    /// for any of the supported protocols.
+    pub fn ignored() -> Self {
+        ChecksumCapabilities {
+            ipv4: Checksum::None,
+            udp: Checksum::None,
+            tcp: Checksum::None,
+            icmpv4: Checksum::None,
+            icmpv6: Checksum::None,
+        }
+    }
+}
+
+/// A description of device capabilities.
+///
+/// Higher-level protocols may achieve higher throughput or lower latency if they consider
+/// the bandwidth or packet size limitations.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct DeviceCapabilities {
+    /// Medium of the device.
+    ///
+    /// This indicates what kind of packet the sent/received bytes are, and determines
+    /// some behaviors of Interface. For example, ARP/NDISC address resolution is only done
+    /// for Ethernet mediums.
+    pub medium: Medium,
+
+    /// Maximum transmission unit.
+    ///
+    /// The network device is unable to send or receive frames larger than the value returned
+    /// by this function.
+    ///
+    /// For Ethernet devices, this is the maximum Ethernet frame size, including the Ethernet header (14 octets), but
+    /// *not* including the Ethernet FCS (4 octets). Therefore, Ethernet MTU = IP MTU + 14.
+    ///
+    /// Note that in Linux and other OSes, "MTU" is the IP MTU, not the Ethernet MTU, even for Ethernet
+    /// devices. This is a common source of confusion.
+    ///
+    /// Most common IP MTU is 1500. Minimum is 576 (for IPv4) or 1280 (for IPv6). Maximum is 9216 octets.
+    pub max_transmission_unit: usize,
+
+    /// Maximum burst size, in terms of MTU.
+    ///
+    /// The network device is unable to send or receive bursts large than the value returned
+    /// by this function.
+    ///
+    /// If `None`, there is no fixed limit on burst size, e.g. if network buffers are
+    /// dynamically allocated.
+    pub max_burst_size: Option<usize>,
+
+    /// Checksum behavior.
+    ///
+    /// If the network device is capable of verifying or computing checksums for some protocols,
+    /// it can request that the stack not do so in software to improve performance.
+    pub checksum: ChecksumCapabilities,
+}
+
+/// An interface for sending and receiving raw network frames.
+///
+/// The interface is based on _tokens_, which are types that allow to receive/transmit a
+/// single packet. The `receive` and `transmit` functions only construct such tokens, the
+/// real sending/receiving operation are performed when the tokens are consumed.
+///
+/// # Examples
+///
+/// An implementation for a simple hardware Ethernet controller could look as follows:
+///
+/// ```rust
+/// use xarxa_driver::{Driver, DeviceCapabilities, Medium, RxToken, TxToken};
+///
+/// struct StmPhy {
+///     rx_buffer: [u8; 1536],
+///     tx_buffer: [u8; 1536],
+/// }
+///
+/// impl Driver for StmPhy {
+///     type RxToken<'a> = StmPhyRxToken<'a> where Self: 'a;
+///     type TxToken<'a> = StmPhyTxToken<'a> where Self: 'a;
+///
+///     fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+///         Some((StmPhyRxToken(&mut self.rx_buffer[..]),
+///               StmPhyTxToken(&mut self.tx_buffer[..])))
+///     }
+///
+///     fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
+///         Some(StmPhyTxToken(&mut self.tx_buffer[..]))
+///     }
+///
+///     fn capabilities(&self) -> DeviceCapabilities {
+///         let mut caps = DeviceCapabilities::default();
+///         caps.max_transmission_unit = 1536;
+///         caps.max_burst_size = Some(1);
+///         caps.medium = Medium::Ethernet;
+///         caps
+///     }
+/// }
+///
+/// struct StmPhyRxToken<'a>(&'a mut [u8]);
+///
+/// impl<'a> RxToken for StmPhyRxToken<'a> {
+///     fn consume<R, F>(self, f: F) -> R
+///         where F: FnOnce(&[u8]) -> R
+///     {
+///         // TODO: receive packet into buffer
+///         f(&self.0)
+///     }
+/// }
+///
+/// struct StmPhyTxToken<'a>(&'a mut [u8]);
+///
+/// impl<'a> TxToken for StmPhyTxToken<'a> {
+///     fn consume<R, F>(self, len: usize, f: F) -> R
+///         where F: FnOnce(&mut [u8]) -> R
+///     {
+///         let result = f(&mut self.0[..len]);
+///         // TODO: send packet out
+///         result
+///     }
+/// }
+/// ```
+pub trait Device {
+    /// A token to receive a single network packet.
+    type RxToken<'a>: RxToken
+    where
+        Self: 'a;
+
+    /// A token to transmit a single network packet.
+    type TxToken<'a>: TxToken
+    where
+        Self: 'a;
+
+    /// Construct a token pair consisting of one receive token and one transmit token.
+    ///
+    /// The additional transmit token makes it possible to generate a reply packet based
+    /// on the contents of the received packet. For example, this makes it possible to
+    /// handle arbitrarily large ICMP echo ("ping") requests, where the all received bytes
+    /// need to be sent back, without heap allocation.
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)>;
+
+    /// Construct a transmit token.
+    ///
+    /// Note that [`TxToken::consume`] is infallible, so it is not allowed to return a token
+    /// if there is no free space and fail later.
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>>;
+
+    /// Get a description of device capabilities.
+    fn capabilities(&self) -> DeviceCapabilities;
+}
+
+impl<T: ?Sized + Device> Device for &mut T {
+    type RxToken<'a>
+        = T::RxToken<'a>
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = T::TxToken<'a>
+    where
+        Self: 'a;
+
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        T::receive(self)
+    }
+
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
+        T::transmit(self)
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        T::capabilities(self)
+    }
+}
+
+/// A token to receive a single network packet.
+pub trait RxToken {
+    /// Consumes the token to receive a single network packet.
+    ///
+    /// This method receives a packet and then calls the given closure `f` with the raw
+    /// packet bytes as argument.
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R;
+
+    /// The packet metadata associated with the frame received by this [`RxToken`].
+    fn meta(&self) -> PacketMeta {
+        PacketMeta::default()
+    }
+}
+
+/// A token to transmit a single network packet.
+pub trait TxToken {
+    /// Consumes the token to send a single network packet.
+    ///
+    /// This method constructs a transmit buffer of size `len` and calls the passed
+    /// closure `f` with a mutable reference to that buffer. The closure should construct
+    /// a valid network packet (e.g. an ethernet packet) in the buffer. When the closure
+    /// returns, the transmit buffer is sent out.
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R;
+
+    /// The packet metadata to be associated with the frame to be transmitted by this [`TxToken`].
+    #[allow(unused_variables)]
+    fn set_meta(&mut self, meta: PacketMeta) {}
+}


### PR DESCRIPTION
The goal is to allow crates implementing `Device` to depend on `xarxa-driver` only. `xarxa-driver` is as small as possible so it will nee dbreaking changes very rarely. This way a new major release of `xarxa` instantly works with all implementations in the ecosystem as long as we don't bump `xarxa-driver`.

This is a second attempt at https://github.com/smoltcp-rs/smoltcp/pull/1080 with the following tradeoffs:

- transmit/receive don't get a timestamp, so `Instant` etc doesn't have to get carried into `xarxa-driver`. I've literally never seen any driver implementation use these timestamps.
- `xarxa_driver::Medium` is an enum with all variants. No cfgs. `xarxa` has its own version of the enum that is cfg-gated, converts when creating the `Interface`, and panics if the Device is of an unsupported medium. This removes the need for the weird `requires-*`, `provides-*` Cargo features.
- Checksum caps aren't gated. Wastes a few bytes at most.

I think the result is much cleaner, I'm probably comfortable with making the tradeoffs above in exchange for having a stable driver crate. Thoughts?

cc @bugadani @MabezDev
