### PR TITLE
tcp:  sending SACK ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ mdns = ["dns"]
 multicast = []
 ## Send and receive the TCP timestamp option (RFC 7323).
 tcp-timestamps = ["tcp"]
+## Send selective acknowledgement ranges (RFC 2018).
+tcp-sack = ["tcp"]
 ## Automatically reply to pings (ICMP echo requests).
 icmp-ping-reply = []
 ## Deliver incoming ICMP error messages (destination unreachable, packet too big, ...) to

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Benchmark source code is available [here](https://github.com/embassy-rs/xarxa-be
   - Delayed ACK (defaults to enabled, can be turned off)
   - Zero-window probes
   - TCP Timestamps (feature `tcp-timestamps`)
+  - TCP SACK, sending ranges only (feature `tcp-sack`)
 - DNS client (feature `dns`)
   - Multiple servers, retransmission with backoff.
   - Multicast DNS for `.local` names (feature `mdns`)
@@ -143,7 +144,7 @@ All of the below is planned. Please open an issue or reach out on [the Matrix ch
 - an equivalent to smoltcp's `any_ip`
 - IPv6 fragmentation and reassembly
 - TCP segmentation offload
-- TCP SACK
+- TCP SACK, acting on ranges received from the peer.
 - Store sockets on a hashmap so packet dispatch is O(1) instead of O(n). (would be optional with a Cargo feature, it's only worth if you have thousands of sockets, i.e. not on embedded)
 - Maybe multithreading. Would require per-socket mutexes etc. (again, optional, would require std)
 

--- a/ci.py
+++ b/ci.py
@@ -66,6 +66,8 @@ EXTRAS = [
     "packetmeta-timestamp,defmt",
     "tcp-timestamps",
     "tcp-timestamps,defmt",
+    "tcp-sack",
+    "tcp-sack,defmt",
     "tcp-reno",
     "tcp-cubic",
     "ipv4-fragmentation",
@@ -83,7 +85,7 @@ EXTRAS = [
     "multicast",
     "multicast,defmt",
     "multicast,icmp-errors,icmp-ping-reply",
-    "std,log,async,icmp-errors,icmp-ping-reply,packetmeta-timestamp,tcp-timestamps,"
+    "std,log,async,icmp-errors,icmp-ping-reply,packetmeta-timestamp,tcp-timestamps,tcp-sack,"
     "packet-log,dhcpv4,dhcpv4-options,multicast,ipv4-fragmentation,ipv4-reassembly,"
     "medium-ieee802154,sixlowpan-fragmentation,sixlowpan-reassembly,slaac",
 ]
@@ -92,7 +94,7 @@ EXTRAS = [
 FULL = (
     "medium-ethernet,medium-ip,medium-ieee802154,ipv4,ipv6,raw,udp,tcp,tcp-listener,"
     "std,log,async,icmp-errors,icmp-ping-reply,multicast,slaac,dhcpv4,dhcpv4-options,"
-    "dns,mdns,packetmeta-timestamp,tcp-timestamps,ipv4-fragmentation,ipv4-reassembly,"
+    "dns,mdns,packetmeta-timestamp,tcp-timestamps,tcp-sack,ipv4-fragmentation,ipv4-reassembly,"
     "sixlowpan-fragmentation,sixlowpan-reassembly"
 )
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -5739,7 +5739,9 @@ pub(crate) mod test {
                 window_len: 1000,
                 window_scale: None,
                 max_seg_size: None,
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: false,
+                #[cfg(feature = "tcp-sack")]
                 sack_ranges: [None; 3],
                 #[cfg(feature = "tcp-timestamps")]
                 timestamp: None,

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -283,7 +283,7 @@ impl Assembler {
 
     /// Iterate over all of the contiguous data ranges.
     ///
-    /// Returns `(offset, size)` tuples for each contiguous data range, where
+    /// Returns `(offset, offset + size)` tuples for each contiguous data range, where
     /// offset is relative to the start of the assembler.
     ///
     ///    Data        Hole        Data

--- a/src/tcp/listener.rs
+++ b/src/tcp/listener.rs
@@ -36,6 +36,7 @@ struct PendingSyn {
     /// The window scale the remote offered, if any.
     remote_win_scale: Option<u8>,
     /// Whether the remote supports selective ACK.
+    #[cfg(feature = "tcp-sack")]
     remote_has_sack: bool,
     /// The MSS the remote advertised (clamped), or the default.
     remote_mss: usize,
@@ -99,6 +100,7 @@ impl TcpListenerState {
             // The window field of a SYN is never scaled.
             remote_win_len: repr.window_len as usize,
             remote_win_scale: repr.window_scale,
+            #[cfg(feature = "tcp-sack")]
             remote_has_sack: repr.sack_permitted,
             remote_mss: match repr.max_seg_size {
                 // A zero MSS is treated as if the option were absent, a tiny
@@ -417,7 +419,10 @@ impl<'d> TcpListener<'_, 'd> {
         s.local_seq_no = TcpSocketState::random_seq_no(rand);
         s.remote_seq_no = syn.remote_seq_no;
         s.remote_last_seq = s.local_seq_no;
-        s.remote_has_sack = syn.remote_has_sack;
+        #[cfg(feature = "tcp-sack")]
+        {
+            s.remote_has_sack = syn.remote_has_sack;
+        }
         s.remote_win_scale = syn.remote_win_scale;
         // Remote doesn't support window scaling, don't do it.
         if syn.remote_win_scale.is_none() {

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -1137,8 +1137,6 @@ impl<'d> TcpSocketState<'d> {
                     // the checks done above imply this.
                     debug_assert!(overlap_start <= overlap_end);
 
-                    self.local_rx_last_seq = Some(repr.seq_number);
-
                     (
                         &repr.payload[overlap_start - segment_start..overlap_end - segment_start],
                         overlap_start - window_start,
@@ -1510,6 +1508,9 @@ impl<'d> TcpSocketState<'d> {
             );
             return None;
         };
+
+        // assembler accepted segment, track sequence number for SACK generation
+        self.local_rx_last_seq = Some(repr.seq_number);
 
         // Place payload octets into the buffer.
         trace!(

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -554,6 +554,7 @@ pub(crate) struct TcpSocketState<'d> {
     /// The receive window scaling factor for remotes which support RFC 1323, None if unsupported.
     remote_win_scale: Option<u8>,
     /// Whether or not the remote supports selective ACK as described in RFC 2018.
+    #[cfg(feature = "tcp-sack")]
     remote_has_sack: bool,
     /// The maximum number of data octets that the remote side may receive.
     remote_mss: usize,
@@ -565,6 +566,7 @@ pub(crate) struct TcpSocketState<'d> {
     /// The timestamp of the last packet received.
     remote_last_ts: Option<Instant>,
     /// The sequence number of the last packet received, used for sACK
+    #[cfg(feature = "tcp-sack")]
     local_rx_last_seq: Option<TcpSeqNumber>,
     /// The ACK number of the last packet received.
     local_rx_last_ack: Option<TcpSeqNumber>,
@@ -586,10 +588,8 @@ pub(crate) struct TcpSocketState<'d> {
     /// Nagle's Algorithm enabled.
     nagle: bool,
 
-    /// Whether we use selective acknowledgements (RFC 2018). When disabled, we neither
-    /// advertise the SACK-permitted option on SYN / SYN|ACK nor emit SACK ranges.
-    sack_enabled: bool,
     /// The last three SACK ranges that were sent to the remote.
+    #[cfg(feature = "tcp-sack")]
     local_sack_history: [Option<(TcpSeqNumber, TcpSeqNumber)>; 3],
 
     /// The congestion control algorithm.
@@ -664,11 +664,13 @@ impl<'d> TcpSocketState<'d> {
             remote_win_len: 0,
             remote_win_shift: rx_cap_log2.saturating_sub(16) as u8,
             remote_win_scale: None,
+            #[cfg(feature = "tcp-sack")]
             remote_has_sack: false,
             remote_mss: DEFAULT_MSS,
             ip_mtu: DEFAULT_IP_MTU,
             remote_last_ts: None,
             local_rx_last_ack: None,
+            #[cfg(feature = "tcp-sack")]
             local_rx_last_seq: None,
             local_rx_dup_acks: 0,
             pending_fast_retransmit: false,
@@ -676,7 +678,7 @@ impl<'d> TcpSocketState<'d> {
             ack_delay_timer: AckDelayTimer::Idle,
             challenge_ack_timer: Instant::from_secs(0),
             nagle: true,
-            sack_enabled: true,
+            #[cfg(feature = "tcp-sack")]
             local_sack_history: [None, None, None],
             #[cfg(feature = "tcp-timestamps")]
             timestamps: false,
@@ -749,7 +751,10 @@ impl<'d> TcpSocketState<'d> {
             self.icmp_error = None;
         }
         self.local_seq_no = TcpSeqNumber::default();
-        self.local_rx_last_seq = None;
+        #[cfg(feature = "tcp-sack")]
+        {
+            self.local_rx_last_seq = None;
+        }
         self.local_rx_last_ack = None;
         self.local_rx_dup_acks = 0;
         self.pending_fast_retransmit = false;
@@ -759,9 +764,11 @@ impl<'d> TcpSocketState<'d> {
         self.remote_last_win = 0;
         self.remote_win_len = 0;
         self.remote_win_scale = None;
-        self.remote_has_sack = false;
+        #[cfg(feature = "tcp-sack")]
+        {
+            self.remote_has_sack = false;
+        }
         self.remote_win_shift = rx_cap_log2.saturating_sub(16) as u8;
-        self.remote_has_sack = false;
         self.remote_mss = DEFAULT_MSS;
         self.ip_mtu = DEFAULT_IP_MTU;
         self.remote_last_ts = None;
@@ -772,7 +779,10 @@ impl<'d> TcpSocketState<'d> {
         self.ack_delay_timer = AckDelayTimer::Idle;
         self.challenge_ack_timer = Instant::from_secs(0);
         self.congestion_controller = congestion::Congestion::new();
-        self.local_sack_history = [None, None, None];
+        #[cfg(feature = "tcp-sack")]
+        {
+            self.local_sack_history = [None, None, None];
+        }
 
         #[cfg(feature = "async")]
         {
@@ -837,7 +847,9 @@ impl<'d> TcpSocketState<'d> {
             window_len: 0,
             window_scale: None,
             max_seg_size: None,
+            #[cfg(feature = "tcp-sack")]
             sack_permitted: false,
+            #[cfg(feature = "tcp-sack")]
             sack_ranges: [None, None, None],
             #[cfg(feature = "tcp-timestamps")]
             timestamp: None,
@@ -901,7 +913,8 @@ impl<'d> TcpSocketState<'d> {
 
         // If the remote supports selective acknowledgement, add the option to the outgoing
         // segment.
-        if self.remote_has_sack && self.sack_enabled {
+        #[cfg(feature = "tcp-sack")]
+        if self.remote_has_sack {
             debug!("sending sACK option with current assembler ranges");
 
             let ack = reply_repr.ack_number.unwrap_or(TcpSeqNumber(0));
@@ -1273,7 +1286,10 @@ impl<'d> TcpSocketState<'d> {
                 self.remote_seq_no = repr.seq_number + 1;
                 self.remote_last_seq = self.local_seq_no + 1;
                 self.remote_last_ack = Some(repr.seq_number);
-                self.remote_has_sack = repr.sack_permitted;
+                #[cfg(feature = "tcp-sack")]
+                {
+                    self.remote_has_sack = repr.sack_permitted;
+                }
                 self.remote_win_scale = repr.window_scale;
                 // Remote doesn't support window scaling, don't do it.
                 if self.remote_win_scale.is_none() {
@@ -1510,7 +1526,10 @@ impl<'d> TcpSocketState<'d> {
         };
 
         // assembler accepted segment, track sequence number for SACK generation
-        self.local_rx_last_seq = Some(repr.seq_number);
+        #[cfg(feature = "tcp-sack")]
+        {
+            self.local_rx_last_seq = Some(repr.seq_number);
+        }
 
         // Place payload octets into the buffer.
         trace!(
@@ -1603,13 +1622,16 @@ impl<'d> TcpSocketState<'d> {
         let local_mss = self.ip_mtu - ip_header_len - TCP_HEADER_LEN;
 
         #[cfg(feature = "tcp-timestamps")]
-        let mut options_len = if self.timestamps { 10 } else { 0 };
+        let mut options_len: usize = if self.timestamps { 10 } else { 0 };
         #[cfg(not(feature = "tcp-timestamps"))]
-        let mut options_len = 0;
+        let mut options_len: usize = 0;
 
-        let sack_blocks = self.sack_range_count();
-        if sack_blocks > 0 {
-            options_len += sack_blocks * 8 + 2;
+        #[cfg(feature = "tcp-sack")]
+        {
+            let sack_blocks = self.sack_range_count();
+            if sack_blocks > 0 {
+                options_len += sack_blocks * 8 + 2;
+            }
         }
         // Options are padded to a multiple of four bytes on the wire.
         options_len = options_len.next_multiple_of(4);
@@ -1726,8 +1748,9 @@ impl<'d> TcpSocketState<'d> {
     ///
     /// Matches count of what `generate_sack_ranges()` generates, as SACK ranges
     ///  are filled with extra ranges from assembler if history is small.
+    #[cfg(feature = "tcp-sack")]
     fn sack_range_count(&self) -> usize {
-        if self.remote_has_sack && self.sack_enabled {
+        if self.remote_has_sack {
             self.assembler.iter_data().take(3).count()
         } else {
             0
@@ -1740,6 +1763,7 @@ impl<'d> TcpSocketState<'d> {
     /// First block contains the triggering island (if it forms an island).
     /// Subsequent blocks are filled from history, and then from the assembler.
     /// Blocks are mapped into the current islands before reporting them.
+    #[cfg(feature = "tcp-sack")]
     fn generate_sack_ranges(&mut self, ack: TcpSeqNumber) -> [Option<(u32, u32)>; 3] {
         if self.assembler.is_empty() {
             self.local_sack_history = [None, None, None];
@@ -1938,7 +1962,9 @@ impl<'d> TcpSocketState<'d> {
             window_len: self.scaled_window(),
             window_scale: None,
             max_seg_size: None,
+            #[cfg(feature = "tcp-sack")]
             sack_permitted: false,
+            #[cfg(feature = "tcp-sack")]
             sack_ranges: [None, None, None],
             #[cfg(feature = "tcp-timestamps")]
             timestamp: self.timestamp_repr(cx.now(), self.last_remote_tsval),
@@ -1948,11 +1974,11 @@ impl<'d> TcpSocketState<'d> {
 
         // We fill blocks before payload sizing to ensure the options header length
         // is taken into account.
+        #[cfg(feature = "tcp-sack")]
         match self.state {
             State::Closed | State::SynSent | State::SynReceived => {}
             _ => {
                 if self.remote_has_sack
-                    && self.sack_enabled
                     && let Some(ack) = repr.ack_number
                 {
                     repr.sack_ranges = self.generate_sack_ranges(ack);
@@ -1979,9 +2005,15 @@ impl<'d> TcpSocketState<'d> {
                 if self.state == State::SynSent {
                     repr.ack_number = None;
                     repr.window_scale = Some(self.remote_win_shift);
-                    repr.sack_permitted = self.sack_enabled;
+                    #[cfg(feature = "tcp-sack")]
+                    {
+                        repr.sack_permitted = true;
+                    }
                 } else {
-                    repr.sack_permitted = self.remote_has_sack && self.sack_enabled;
+                    #[cfg(feature = "tcp-sack")]
+                    {
+                        repr.sack_permitted = self.remote_has_sack;
+                    }
                     repr.window_scale = self.remote_win_scale.map(|_| self.remote_win_shift);
                 }
             }
@@ -2436,13 +2468,6 @@ impl<'d> TcpSocket<'_, 'd> {
         self.inner().nagle
     }
 
-    /// Return whether selective acknowledgements (RFC 2018) are enabled.
-    ///
-    /// See also the [set_sack_enabled](#method.set_sack_enabled) method.
-    pub fn sack_enabled(&self) -> bool {
-        self.inner().sack_enabled
-    }
-
     /// Set the timeout duration.
     ///
     /// A socket with a timeout duration set will abort the connection if either of the following
@@ -2479,16 +2504,6 @@ impl<'d> TcpSocket<'_, 'd> {
     /// has ACK delay enabled.
     pub fn set_nagle_enabled(&mut self, enabled: bool) {
         self.inner_mut().nagle = enabled
-    }
-
-    /// Enable or disable selective acknowledgements (SACK, RFC 2018).
-    ///
-    /// By default, SACK is enabled. When enabled, the socket advertises the SACK-permitted
-    /// option on the SYN it sends (and mirrors the peer's on a SYN|ACK), and emits SACK ranges
-    /// for out-of-order data. When disabled, the socket does neither, so the connection falls
-    /// back to cumulative ACKs only.
-    pub fn set_sack_enabled(&mut self, enabled: bool) {
-        self.inner_mut().sack_enabled = enabled
     }
 
     /// Return the keep-alive interval.
@@ -3027,7 +3042,9 @@ mod test {
         window_len: 256,
         window_scale: None,
         max_seg_size: None,
+        #[cfg(feature = "tcp-sack")]
         sack_permitted: false,
+        #[cfg(feature = "tcp-sack")]
         sack_ranges: [None, None, None],
         #[cfg(feature = "tcp-timestamps")]
         timestamp: None,
@@ -3043,7 +3060,9 @@ mod test {
         window_len: 64,
         window_scale: None,
         max_seg_size: None,
+        #[cfg(feature = "tcp-sack")]
         sack_permitted: false,
+        #[cfg(feature = "tcp-sack")]
         sack_ranges: [None, None, None],
         #[cfg(feature = "tcp-timestamps")]
         timestamp: None,
@@ -4017,6 +4036,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 #[cfg(feature = "tcp-timestamps")]
                 timestamp: Some(TcpTimestampRepr::new(0, 0)),
@@ -4050,6 +4070,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 #[cfg(feature = "tcp-timestamps")]
                 timestamp: Some(TcpTimestampRepr::new(0, 0)),
@@ -4084,6 +4105,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 #[cfg(feature = "tcp-timestamps")]
                 timestamp: Some(TcpTimestampRepr::new(0, 0)),
@@ -4105,62 +4127,10 @@ mod test {
         assert_eq!(s.remote_mss, DEFAULT_MSS);
     }
 
-    #[test]
-    fn test_connect_sack_disabled() {
-        let mut s = socket();
-        s.local_seq_no = LOCAL_SEQ;
-        s.view().set_sack_enabled(false);
-        s.view().connect(REMOTE_END, LOCAL_END.port).unwrap();
-
-        // The SYN must not carry the SACK-permitted option.
-        recv!(
-            s,
-            [TcpRepr {
-                control: TcpControl::Syn,
-                seq_number: LOCAL_SEQ,
-                ack_number: None,
-                max_seg_size: Some(BASE_MSS),
-                window_scale: Some(0),
-                sack_permitted: false,
-                #[cfg(feature = "tcp-timestamps")]
-                timestamp: Some(TcpTimestampRepr::new(0, 0)),
-                ..RECV_TEMPL
-            }]
-        );
-
-        // Ensure a poorly behaved remote adding a SACK option when we haven't,
-        // cannot cause us to send SACK ranges.
-        send!(
-            s,
-            TcpRepr {
-                control: TcpControl::Syn,
-                seq_number: REMOTE_SEQ,
-                ack_number: Some(LOCAL_SEQ + 1),
-                max_seg_size: Some(BASE_MSS - 80),
-                window_scale: Some(0),
-                sack_permitted: true,
-                ..SEND_TEMPL
-            }
-        );
-
-        assert!(s.remote_has_sack);
-
-        recv!(
-            s,
-            [TcpRepr {
-                seq_number: LOCAL_SEQ + 1,
-                ack_number: Some(REMOTE_SEQ + 1),
-                ..RECV_TEMPL
-            }]
-        );
-
-        assert_eq!(s.state, State::Established);
-        sack_ranges_are_never_emitted(&mut s);
-    }
-
     /// RFC 2018: If the data receiver has not received a SACK-Permitted option
     /// for a given connection, it MUST NOT send SACK options on that connection.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_connect_sack_not_offered_by_remote() {
         let mut s = socket_syn_sent();
         recv!(
@@ -4191,7 +4161,6 @@ mod test {
         );
 
         assert!(!s.remote_has_sack);
-        assert!(s.view().sack_enabled());
 
         recv!(
             s,
@@ -4206,49 +4175,15 @@ mod test {
         sack_ranges_are_never_emitted(&mut s);
     }
 
-    #[test]
-    fn test_syn_received_sack_disabled() {
-        let mut s = socket_syn_received();
-        s.view().set_sack_enabled(false);
-
-        // Ensure the remote offering SACK results when we do not, cannot
-        // cause us to send SACK ranges.
-        s.remote_has_sack = true;
-
-        recv!(
-            s,
-            [TcpRepr {
-                control: TcpControl::Syn,
-                seq_number: LOCAL_SEQ,
-                ack_number: Some(REMOTE_SEQ + 1),
-                max_seg_size: Some(BASE_MSS),
-                sack_permitted: false,
-                ..RECV_TEMPL
-            }]
-        );
-
-        send!(
-            s,
-            TcpRepr {
-                seq_number: REMOTE_SEQ + 1,
-                ack_number: Some(LOCAL_SEQ + 1),
-                ..SEND_TEMPL
-            }
-        );
-
-        assert_eq!(s.state, State::Established);
-        sack_ranges_are_never_emitted(&mut s);
-    }
-
     /// RFC 2018: If the data receiver has not received a SACK-Permitted option
     /// for a given connection, it MUST NOT send SACK options on that connection.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_syn_received_sack_not_offered_by_remote() {
         let mut s = socket_syn_received();
 
         // Ensure the remote not sending SACK results in SACK options not being sent.
         assert!(!s.remote_has_sack);
-        assert!(s.view().sack_enabled());
         recv!(
             s,
             [TcpRepr {
@@ -4275,6 +4210,7 @@ mod test {
 
     // Ensure that SACK ranges are not attached to ACKs after receiving out of
     // order segments. These segment should exist within the assembler however.
+    #[cfg(feature = "tcp-sack")]
     fn sack_ranges_are_never_emitted(mut s: &mut TestSocket) {
         for offset in [6, 18] {
             send!(
@@ -4422,6 +4358,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4461,6 +4398,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4533,6 +4471,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4569,6 +4508,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4657,6 +4597,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4687,6 +4628,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4723,6 +4665,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4756,6 +4699,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_syn_sent_sack_option() {
         let mut s = socket_syn_sent();
         recv!(
@@ -4841,6 +4785,7 @@ mod test {
                     max_seg_size: Some(BASE_MSS),
                     window_scale: Some(*shift_amt),
                     window_len: u16::try_from(*buffer_size).unwrap_or(u16::MAX),
+                    #[cfg(feature = "tcp-sack")]
                     sack_permitted: true,
                     #[cfg(feature = "tcp-timestamps")]
                     timestamp: Some(TcpTimestampRepr::new(0, 0)),
@@ -4863,6 +4808,7 @@ mod test {
                 // scaling does NOT apply to the window value in SYN packets
                 window_len: 65535,
                 window_scale: Some(5),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -4897,6 +4843,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -5000,6 +4947,7 @@ mod test {
     /// Outcome:
     /// The SACK ranges are reported correctly with no overflow.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_established_sack_no_overflow_on_near_max_seqnumber() {
         let mut s = socket_established();
         s.remote_has_sack = true;
@@ -5636,6 +5584,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(MTU_MSS as u16),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 ..RECV_TEMPL
             }]
@@ -5703,6 +5652,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 timestamp: Some(TcpTimestampRepr::new(0, 0)),
                 ..RECV_TEMPL
@@ -6811,8 +6761,11 @@ mod test {
     #[test]
     fn test_reset_clears_connection_state() {
         let mut s = socket_established();
-        s.remote_has_sack = true;
-        s.local_rx_last_seq = Some(TcpSeqNumber(42));
+        #[cfg(feature = "tcp-sack")]
+        {
+            s.remote_has_sack = true;
+            s.local_rx_last_seq = Some(TcpSeqNumber(42));
+        }
         s.local_rx_last_ack = Some(TcpSeqNumber(42));
         s.local_rx_dup_acks = 2;
         s.pending_fast_retransmit = true;
@@ -6823,8 +6776,11 @@ mod test {
 
         s.reset();
 
-        assert!(!s.remote_has_sack);
-        assert_eq!(s.local_rx_last_seq, None);
+        #[cfg(feature = "tcp-sack")]
+        {
+            assert!(!s.remote_has_sack);
+            assert_eq!(s.local_rx_last_seq, None);
+        }
         assert_eq!(s.local_rx_last_ack, None);
         assert_eq!(s.local_rx_dup_acks, 0);
         assert!(!s.pending_fast_retransmit);
@@ -8860,6 +8816,7 @@ mod test {
             ack_number: None,
             max_seg_size: Some(BASE_MSS),
             window_scale: Some(0),
+            #[cfg(feature = "tcp-sack")]
             sack_permitted: true,
             #[cfg(feature = "tcp-timestamps")]
             timestamp: Some(TcpTimestampRepr::new(150, 0)),
@@ -9999,6 +9956,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 timestamp: Some(TcpTimestampRepr::new(0, 0)),
                 ..RECV_TEMPL
@@ -10046,6 +10004,7 @@ mod test {
                 ack_number: None,
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
+                #[cfg(feature = "tcp-sack")]
                 sack_permitted: true,
                 timestamp: Some(TcpTimestampRepr::new(0, 0)),
                 ..RECV_TEMPL
@@ -10082,6 +10041,7 @@ mod test {
     // =========================================================================================//
 
     /// Creates a SACK range from segment's left and right edges.
+    #[cfg(feature = "tcp-sack")]
     fn block(left: usize, right: usize) -> Option<(u32, u32)> {
         Some(((REMOTE_SEQ + 1 + left).0 as u32, (REMOTE_SEQ + 1 + right).0 as u32))
     }
@@ -10090,11 +10050,13 @@ mod test {
     ///
     /// RFC 2018: Assume the left window edge is 5000 and that the data transmitter sends [...]
     /// segments, each containing 500 data bytes.
+    #[cfg(feature = "tcp-sack")]
     fn setup_rfc2018_cases() -> (TestSocket, Vec<u8>) {
         setup_rfc2018_cases_with_rx_buffer(4000)
     }
 
     /// As `setup_rfc2018_cases()`, with the receive buffer size chosen by the caller.
+    #[cfg(feature = "tcp-sack")]
     fn setup_rfc2018_cases_with_rx_buffer(rx_len: usize) -> (TestSocket, Vec<u8>) {
         let mut s = socket_established_with_buffer_sizes(4000, rx_len);
         s.remote_has_sack = true;
@@ -10164,6 +10126,7 @@ mod test {
     /// |    8500     |    5000     |     5500      |      9000      |
     /// +-------------+-------------+---------------+----------------+
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_rfc2018_case_2() {
         let (mut s, segment) = setup_rfc2018_cases();
 
@@ -10223,6 +10186,7 @@ mod test {
     /// |    7500    |   8500   |        |        |        |        |        |        |
     /// +------------+----------+--------+--------+--------+--------+--------+--------+
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_rfc2018_case_3() {
         let (mut s, segment) = setup_rfc2018_cases();
 
@@ -10390,6 +10354,7 @@ mod test {
     /// | (pure ACK) |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
     /// +------------+----------+--------+--------+--------+--------+--------+--------+
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_not_affected_by_pure_ack() {
         let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(5000);
 
@@ -10551,6 +10516,7 @@ mod test {
     /// | (pure ACK) |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
     /// +------------+----------+--------+--------+--------+--------+--------+--------+
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_not_affected_by_reordered_pure_ack() {
         let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(5000);
 
@@ -10685,6 +10651,7 @@ mod test {
     /// block is 10 option bytes, padded to 12 on the wire. This test does not
     /// negotiate timestamps, so the option length is 12 and the remainder is also 12.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_emitted_on_data_segments() {
         const REMOTE_MSS: usize = 128;
         const ONE_BLOCK_OPTS: usize = 12;
@@ -10746,6 +10713,7 @@ mod test {
     /// Outcome:
     /// The zero window probe carries the previously announced SACK range.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_emitted_on_zero_window_probe() {
         let mut s = socket_established_with_buffer_sizes(64, 128);
         s.remote_has_sack = true;
@@ -10806,6 +10774,7 @@ mod test {
     /// contain a SACK block and the window advertised should not include the bytes
     /// from the out-of-order segment.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_emitted_on_window_update() {
         let mut s = socket_established_with_buffer_sizes(64, 128);
         s.remote_has_sack = true;
@@ -10885,6 +10854,7 @@ mod test {
     /// in the order that they were received. When segment 1 is received and advances
     /// the left edge, SACK ranges should now contain that fourth island.
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_reports_three_of_four_islands() {
         let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(5000);
 
@@ -10961,6 +10931,7 @@ mod test {
     /// |  6500..6501  |  5000  |  6000  |  7001  |        |        |
     /// +--------------+--------+--------+--------+--------+--------+
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_is_an_exclusive_range() {
         let (mut s, segment) = setup_rfc2018_cases();
 
@@ -11061,6 +11032,7 @@ mod test {
     /// |  transmit  |   5500   |  9000  |  9500  |  8000  |  8500  |  7000  |  7500  |
     /// +------------+----------+--------+--------+--------+--------+--------+--------+
     #[test]
+    #[cfg(feature = "tcp-sack")]
     fn test_sack_works_when_assembler_rejects_segment() {
         // The window must stay wide enough that segment 10000 is still inside it,
         // so the assembler turns it away rather than the window check.
@@ -11258,7 +11230,9 @@ mod stack_test {
         window_len: 1024,
         window_scale: None,
         max_seg_size: None,
+        #[cfg(feature = "tcp-sack")]
         sack_permitted: false,
+        #[cfg(feature = "tcp-sack")]
         sack_ranges: [None, None, None],
         #[cfg(feature = "tcp-timestamps")]
         timestamp: None,

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -1752,7 +1752,7 @@ impl<'d> TcpSocketState<'d> {
             self.assembler
                 .iter_data()
                 .map(|(l, r)| (ack + l, ack + r))
-                .find(|&(l, r)| l <= seq && seq <= r)
+                .find(|&(l, r)| l <= seq && seq < r)
         };
 
         // RFC 2018: the first SACK block MUST specify the contiguous block of

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -624,9 +624,6 @@ const DEFAULT_MSS: usize = 536;
 /// Without it, a peer advertising a tiny MSS could force segments to carry little
 /// or no payload once the TCP options length is subtracted from the effective MSS,
 /// stalling the connection in an endless stream of empty segments.
-///
-/// Must exceed the maximum possible length of the TCP options (currently 12, for
-/// timestamps) so that every segment carries some payload.
 const MIN_REMOTE_MSS: usize = 48;
 
 impl<'d> TcpSocketState<'d> {

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -10210,7 +10210,7 @@ mod test {
     /// |    8500    |   (lost) |        |        |        |        |        |        |
     /// +------------+----------+--------+--------+--------+--------+--------+--------+
     ///
-    /// Now, the 4th, 2nd and  6th (not specified in RFC test case) s egments are
+    /// Now, the 4th, 2nd and 6th (not specified in RFC test case) segments are
     /// received:
     ///
     ///                          +-----------------+-----------------+-----------------+
@@ -10379,7 +10379,7 @@ mod test {
     /// |    6000    |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
     /// +------------+----------+--------+--------+--------+--------+--------+--------+
     ///
-    /// A pure ACK from the transmitter now arrives. It carries no data and  has a
+    /// A pure ACK from the transmitter now arrives. It carries no data and has a
     /// sequence number of 9000, right on the edge of the data held by the assembler.
     ///
     ///                          +-----------------+-----------------+-----------------+
@@ -10677,13 +10677,13 @@ mod test {
 
     /// Case:
     /// One island is held, so every outgoing ACK carries one SACK block. The socket
-    /// then gets one MSS of data top send.
+    /// then gets one MSS of data to send.
     ///
     /// Outcome:
     /// The data should be split into two segments, due to the length of the options.
-    /// One full segment should be sent, and another carrying the remainder. With the
-    /// option length being 12 - TS + SACK (one block) - the remainder should also
-    /// be 12.
+    /// One full segment should be sent, and another carrying the remainder. One SACK
+    /// block is 10 option bytes, padded to 12 on the wire. This test does not
+    /// negotiate timestamps, so the option length is 12 and the remainder is also 12.
     #[test]
     fn test_sack_emitted_on_data_segments() {
         const REMOTE_MSS: usize = 128;
@@ -10744,7 +10744,7 @@ mod test {
     /// socket and a zero window probe is sent.
     ///
     /// Outcome:
-    /// The zerow window probe carries the previously annoucned SACK range.
+    /// The zero window probe carries the previously announced SACK range.
     #[test]
     fn test_sack_emitted_on_zero_window_probe() {
         let mut s = socket_established_with_buffer_sizes(64, 128);
@@ -10881,7 +10881,7 @@ mod test {
     /// +--------------+--------+--------+--------+--------+--------+--------+--------+
     ///
     /// Outcome:
-    /// Four islans shuoldbe held within the assembler, but only three blocks reported
+    /// Four islands should be held within the assembler, but only three blocks reported
     /// in the order that they were received. When segment 1 is received and advances
     /// the left edge, SACK ranges should now contain that fourth island.
     #[test]
@@ -10915,7 +10915,7 @@ mod test {
 
         assert_eq!(s.assembler.iter_data().count(), 4);
 
-        // Advancing the left edge should remove one island and let another be reported:w
+        // Advancing the left edge should remove one island and let another be reported
         send!(
             s,
             TcpRepr {

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -586,6 +586,12 @@ pub(crate) struct TcpSocketState<'d> {
     /// Nagle's Algorithm enabled.
     nagle: bool,
 
+    /// Whether we use selective acknowledgements (RFC 2018). When disabled, we neither
+    /// advertise the SACK-permitted option on SYN / SYN|ACK nor emit SACK ranges.
+    sack_enabled: bool,
+    /// The last three SACK ranges that were sent to the remote.
+    local_sack_history: [Option<(TcpSeqNumber, TcpSeqNumber)>; 3],
+
     /// The congestion control algorithm.
     congestion_controller: congestion::Congestion,
 
@@ -673,6 +679,8 @@ impl<'d> TcpSocketState<'d> {
             ack_delay_timer: AckDelayTimer::Idle,
             challenge_ack_timer: Instant::from_secs(0),
             nagle: true,
+            sack_enabled: true,
+            local_sack_history: [None, None, None],
             #[cfg(feature = "tcp-timestamps")]
             timestamps: false,
             #[cfg(feature = "tcp-timestamps")]
@@ -762,6 +770,7 @@ impl<'d> TcpSocketState<'d> {
         self.ack_delay_timer = AckDelayTimer::Idle;
         self.challenge_ack_timer = Instant::from_secs(0);
         self.congestion_controller = congestion::Congestion::new();
+        self.local_sack_history = [None, None, None];
 
         #[cfg(feature = "async")]
         {
@@ -890,41 +899,11 @@ impl<'d> TcpSocketState<'d> {
 
         // If the remote supports selective acknowledgement, add the option to the outgoing
         // segment.
-        if self.remote_has_sack {
+        if self.remote_has_sack && self.sack_enabled {
             debug!("sending sACK option with current assembler ranges");
 
-            // RFC 2018: The first SACK block (i.e., the one immediately following the kind and
-            // length fields in the option) MUST specify the contiguous block of data containing
-            // the segment which triggered this ACK, unless that segment advanced the
-            // Acknowledgment Number field in the header.
-            reply_repr.sack_ranges[0] = None;
-
             let ack = reply_repr.ack_number.unwrap_or(TcpSeqNumber(0));
-
-            if let Some(last_seg_seq) = self.local_rx_last_seq {
-                reply_repr.sack_ranges[0] = self
-                    .assembler
-                    .iter_data()
-                    .map(|(left, right)| (ack + left, ack + right))
-                    .find(|&(left, right)| left <= last_seg_seq && right >= last_seg_seq)
-                    .map(|(left, right)| (left.0 as u32, right.0 as u32));
-            }
-
-            if reply_repr.sack_ranges[0].is_none() {
-                // The matching segment was removed from the assembler, meaning the acknowledgement
-                // number has advanced, or there was no previous sACK.
-                //
-                // While the RFC says we SHOULD keep a list of reported sACK ranges, and iterate
-                // through those, that is currently infeasible. Instead, we offer the range with
-                // the lowest sequence number (if one exists) to hint at what segments would
-                // most quickly advance the acknowledgement number.
-                reply_repr.sack_ranges[0] = self
-                    .assembler
-                    .iter_data()
-                    .map(|(left, right)| (ack + left, ack + right))
-                    .next()
-                    .map(|(left, right)| (left.0 as u32, right.0 as u32));
-            }
+            reply_repr.sack_ranges = self.generate_sack_ranges(ack);
         }
 
         reply_repr
@@ -1615,13 +1594,23 @@ impl<'d> TcpSocketState<'d> {
             IpAddress::Ipv6(_) => crate::wire::IPV6_HEADER_LEN,
         };
 
-        // The effective max segment size, taking into account the options and the local and remote limits.
-        #[cfg(feature = "tcp-timestamps")]
-        let options_len = if self.timestamps { 12 } else { 0 };
-        #[cfg(not(feature = "tcp-timestamps"))]
-        let options_len = 0;
-
+        // The effective max segment size, taking into account our and remote's limits.
+        // Per RFC 6691 §2 the advertised MSS counts payload only and excludes TCP options, so
+        // subtract the options a data segment carries.
         let local_mss = self.ip_mtu - ip_header_len - TCP_HEADER_LEN;
+
+        #[cfg(feature = "tcp-timestamps")]
+        let mut options_len = if self.timestamps { 10 } else { 0 };
+        #[cfg(not(feature = "tcp-timestamps"))]
+        let mut options_len = 0;
+
+        let sack_blocks = self.sack_range_count();
+        if sack_blocks > 0 {
+            options_len += sack_blocks * 8 + 2;
+        }
+        // Options are padded to a multiple of four bytes on the wire.
+        options_len = options_len.next_multiple_of(4);
+
         let effective_mss = local_mss.min(self.remote_mss).saturating_sub(options_len);
 
         // Have we sent data that hasn't been ACKed yet?
@@ -1728,6 +1717,84 @@ impl<'d> TcpSocketState<'d> {
             }
             _ => false,
         }
+    }
+
+    /// The number of SACK blocks the next emitted ACK will carry.
+    ///
+    /// Matches count of what `generate_sack_ranges()` generates, as SACK ranges
+    ///  are filled with extra ranges from assembler if history is small.
+    fn sack_range_count(&self) -> usize {
+        if self.remote_has_sack && self.sack_enabled {
+            self.assembler.iter_data().take(3).count()
+        } else {
+            0
+        }
+    }
+
+    /// Build the SACK blocks for an outgoing ACK, per RFC 2018, and record
+    /// what was reported in `local_sack_history`.
+    ///
+    /// First block contains the triggering island (if it forms an island).
+    /// Subsequent blocks are filled from history, and then from the assembler.
+    /// Blocks are mapped into the current islands before reporting them.
+    fn generate_sack_ranges(&mut self, ack: TcpSeqNumber) -> [Option<(u32, u32)>; 3] {
+        if self.assembler.is_empty() {
+            self.local_sack_history = [None, None, None];
+            return [None, None, None];
+        }
+
+        let mut blocks = [None, None, None];
+        let mut n = 0;
+
+        let find_block = |seq: TcpSeqNumber| {
+            self.assembler
+                .iter_data()
+                .map(|(l, r)| (ack + l, ack + r))
+                .find(|&(l, r)| l <= seq && seq <= r)
+        };
+
+        // RFC 2018: the first SACK block MUST specify the contiguous block of
+        // data containing the segment which triggered this ACK, unless that
+        // segment advanced the Acknowledgment Number field in the header.
+        if let Some(seq) = self.local_rx_last_seq
+            && let Some(block) = find_block(seq)
+        {
+            blocks[0] = Some(block);
+            n = 1;
+        }
+
+        // RFC 2018: The SACK option SHOULD be filled out by repeating the most
+        // recently reported SACK blocks that are not subsets of a SACK block
+        // already included in the SACK option being constructed.
+        //
+        // Maps each old block onto its current island, ensuring no duplicates.
+        for block in self.local_sack_history.iter().flatten() {
+            if n == blocks.len() {
+                break;
+            }
+            if let Some(island) = find_block(block.0)
+                && !blocks[..n].contains(&Some(island))
+            {
+                blocks[n] = Some(island);
+                n += 1;
+            }
+        }
+
+        // Remaining holes are filled from the assembler, lowest island first.
+        for island in self.assembler.iter_data().map(|(l, r)| (ack + l, ack + r)) {
+            if n == blocks.len() {
+                break;
+            }
+            if !blocks[..n].contains(&Some(island)) {
+                blocks[n] = Some(island);
+                n += 1;
+            }
+        }
+
+        self.local_sack_history = blocks;
+
+        // convert blocks to wire representation
+        blocks.map(|block| block.map(|(l, r)| (l.0 as u32, r.0 as u32)))
     }
 
     pub(crate) fn dispatch<F, E>(&mut self, cx: &mut TxContext<'_, '_>, emit: F) -> Result<(), E>
@@ -1876,6 +1943,20 @@ impl<'d> TcpSocketState<'d> {
             payload2: &[],
         };
 
+        // We fill blocks before payload sizing to ensure the options header length
+        // is taken into account.
+        match self.state {
+            State::Closed | State::SynSent | State::SynReceived => {}
+            _ => {
+                if self.remote_has_sack
+                    && self.sack_enabled
+                    && let Some(ack) = repr.ack_number
+                {
+                    repr.sack_ranges = self.generate_sack_ranges(ack);
+                }
+            }
+        }
+
         let mut is_zero_window_probe = false;
 
         match self.state {
@@ -1895,9 +1976,9 @@ impl<'d> TcpSocketState<'d> {
                 if self.state == State::SynSent {
                     repr.ack_number = None;
                     repr.window_scale = Some(self.remote_win_shift);
-                    repr.sack_permitted = true;
+                    repr.sack_permitted = self.sack_enabled;
                 } else {
-                    repr.sack_permitted = self.remote_has_sack;
+                    repr.sack_permitted = self.remote_has_sack && self.sack_enabled;
                     repr.window_scale = self.remote_win_scale.map(|_| self.remote_win_shift);
                 }
             }
@@ -2352,6 +2433,13 @@ impl<'d> TcpSocket<'_, 'd> {
         self.inner().nagle
     }
 
+    /// Return whether selective acknowledgements (RFC 2018) are enabled.
+    ///
+    /// See also the [set_sack_enabled](#method.set_sack_enabled) method.
+    pub fn sack_enabled(&self) -> bool {
+        self.inner().sack_enabled
+    }
+
     /// Set the timeout duration.
     ///
     /// A socket with a timeout duration set will abort the connection if either of the following
@@ -2388,6 +2476,16 @@ impl<'d> TcpSocket<'_, 'd> {
     /// has ACK delay enabled.
     pub fn set_nagle_enabled(&mut self, enabled: bool) {
         self.inner_mut().nagle = enabled
+    }
+
+    /// Enable or disable selective acknowledgements (SACK, RFC 2018).
+    ///
+    /// By default, SACK is enabled. When enabled, the socket advertises the SACK-permitted
+    /// option on the SYN it sends (and mirrors the peer's on a SYN|ACK), and emits SACK ranges
+    /// for out-of-order data. When disabled, the socket does neither, so the connection falls
+    /// back to cumulative ACKs only.
+    pub fn set_sack_enabled(&mut self, enabled: bool) {
+        self.inner_mut().sack_enabled = enabled
     }
 
     /// Return the keep-alive interval.
@@ -4002,6 +4100,46 @@ mod test {
         );
         assert_eq!(s.state, State::Established);
         assert_eq!(s.remote_mss, DEFAULT_MSS);
+    }
+
+    #[test]
+    fn test_connect_sack_disabled() {
+        let mut s = socket();
+        s.local_seq_no = LOCAL_SEQ;
+        s.view().set_sack_enabled(false);
+        s.view().connect(REMOTE_END, LOCAL_END.port).unwrap();
+        // The SYN must not carry the SACK-permitted option.
+        recv!(
+            s,
+            [TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: LOCAL_SEQ,
+                ack_number: None,
+                max_seg_size: Some(BASE_MSS),
+                window_scale: Some(0),
+                sack_permitted: false,
+                ..RECV_TEMPL
+            }]
+        );
+    }
+
+    #[test]
+    fn test_syn_received_sack_disabled() {
+        // Even when the peer offers SACK, a SACK-disabled socket must not mirror it on SYN|ACK.
+        let mut s = socket_syn_received();
+        s.remote_has_sack = true;
+        s.view().set_sack_enabled(false);
+        recv!(
+            s,
+            [TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: LOCAL_SEQ,
+                ack_number: Some(REMOTE_SEQ + 1),
+                max_seg_size: Some(BASE_MSS),
+                sack_permitted: false,
+                ..RECV_TEMPL
+            }]
+        );
     }
 
     #[test]

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -4110,6 +4110,7 @@ mod test {
         s.local_seq_no = LOCAL_SEQ;
         s.view().set_sack_enabled(false);
         s.view().connect(REMOTE_END, LOCAL_END.port).unwrap();
+
         // The SYN must not carry the SACK-permitted option.
         recv!(
             s,
@@ -4125,14 +4126,94 @@ mod test {
                 ..RECV_TEMPL
             }]
         );
+
+        // Ensure a poorly behaved remote adding a SACK option when we haven't,
+        // cannot cause us to send SACK ranges.
+        send!(
+            s,
+            TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: REMOTE_SEQ,
+                ack_number: Some(LOCAL_SEQ + 1),
+                max_seg_size: Some(BASE_MSS - 80),
+                window_scale: Some(0),
+                sack_permitted: true,
+                ..SEND_TEMPL
+            }
+        );
+
+        assert!(s.remote_has_sack);
+
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1),
+                ..RECV_TEMPL
+            }]
+        );
+
+        assert_eq!(s.state, State::Established);
+        sack_ranges_are_never_emitted(&mut s);
+    }
+
+    /// RFC 2018: If the data receiver has not received a SACK-Permitted option
+    /// for a given connection, it MUST NOT send SACK options on that connection.
+    #[test]
+    fn test_connect_sack_not_offered_by_remote() {
+        let mut s = socket_syn_sent();
+        recv!(
+            s,
+            [TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: LOCAL_SEQ,
+                ack_number: None,
+                max_seg_size: Some(BASE_MSS),
+                window_scale: Some(0),
+                sack_permitted: true,
+                ..RECV_TEMPL
+            }]
+        );
+
+        // Ensure the remote rejecting SACK results in SACK options not being sent.
+        send!(
+            s,
+            TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: REMOTE_SEQ,
+                ack_number: Some(LOCAL_SEQ + 1),
+                max_seg_size: Some(BASE_MSS - 80),
+                window_scale: Some(0),
+                sack_permitted: false,
+                ..SEND_TEMPL
+            }
+        );
+
+        assert!(!s.remote_has_sack);
+        assert!(s.view().sack_enabled());
+
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1),
+                ..RECV_TEMPL
+            }]
+        );
+
+        assert_eq!(s.state, State::Established);
+        sack_ranges_are_never_emitted(&mut s);
     }
 
     #[test]
     fn test_syn_received_sack_disabled() {
-        // Even when the peer offers SACK, a SACK-disabled socket must not mirror it on SYN|ACK.
         let mut s = socket_syn_received();
-        s.remote_has_sack = true;
         s.view().set_sack_enabled(false);
+
+        // Ensure the remote offering SACK results when we do not, cannot
+        // cause us to send SACK ranges.
+        s.remote_has_sack = true;
+
         recv!(
             s,
             [TcpRepr {
@@ -4144,6 +4225,91 @@ mod test {
                 ..RECV_TEMPL
             }]
         );
+
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1,
+                ack_number: Some(LOCAL_SEQ + 1),
+                ..SEND_TEMPL
+            }
+        );
+
+        assert_eq!(s.state, State::Established);
+        sack_ranges_are_never_emitted(&mut s);
+    }
+
+    /// RFC 2018: If the data receiver has not received a SACK-Permitted option
+    /// for a given connection, it MUST NOT send SACK options on that connection.
+    #[test]
+    fn test_syn_received_sack_not_offered_by_remote() {
+        let mut s = socket_syn_received();
+
+        // Ensure the remote not sending SACK results in SACK options not being sent.
+        assert!(!s.remote_has_sack);
+        assert!(s.view().sack_enabled());
+        recv!(
+            s,
+            [TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: LOCAL_SEQ,
+                ack_number: Some(REMOTE_SEQ + 1),
+                max_seg_size: Some(BASE_MSS),
+                sack_permitted: false,
+                ..RECV_TEMPL
+            }]
+        );
+
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1,
+                ack_number: Some(LOCAL_SEQ + 1),
+                ..SEND_TEMPL
+            }
+        );
+        assert_eq!(s.state, State::Established);
+        sack_ranges_are_never_emitted(&mut s);
+    }
+
+    // Ensure that SACK ranges are not attached to ACKs after receiving out of
+    // order segments. These segment should exist within the assembler however.
+    fn sack_ranges_are_never_emitted(mut s: &mut TestSocket) {
+        for offset in [6, 18] {
+            send!(
+                s,
+                TcpRepr {
+                    seq_number: REMOTE_SEQ + 1 + offset,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    payload: b"abcdef",
+                    ..SEND_TEMPL
+                },
+                Some(TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1),
+                    sack_ranges: [None, None, None],
+                    ..RECV_TEMPL
+                })
+            );
+        }
+
+        // No option space is reserved, so the MSS is not reduced.
+        assert_eq!(s.sack_range_count(), 0);
+
+        // The dispatch path is gated by the same conjunction.
+        s.view().send_slice(b"x").unwrap();
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1),
+                payload: b"x",
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            }]
+        );
+
+        assert_eq!(s.assembler.iter_data().count(), 2);
     }
 
     #[test]
@@ -4826,106 +4992,12 @@ mod test {
         assert_eq!(&mut peeked_buf[..actually_peeked], &mut recv_buf[..actually_recvd]);
     }
 
-    fn setup_rfc2018_cases() -> (TestSocket, Vec<u8>) {
-        // This is a utility function used by the tests for RFC 2018 cases. It configures a socket
-        // in a particular way suitable for those cases.
-        //
-        // RFC 2018: Assume the left window edge is 5000 and that the data transmitter sends [...]
-        // segments, each containing 500 data bytes.
-        let mut s = socket_established_with_buffer_sizes(4000, 4000);
-        s.remote_has_sack = true;
-
-        // create a segment that is 500 bytes long
-        let mut segment: Vec<u8> = Vec::with_capacity(500);
-
-        // move the last ack to 5000 by sending ten of them
-        for _ in 0..50 {
-            segment.extend_from_slice(b"abcdefghij")
-        }
-        for offset in (0..5000).step_by(500) {
-            send!(
-                s,
-                TcpRepr {
-                    seq_number: REMOTE_SEQ + 1 + offset,
-                    ack_number: Some(LOCAL_SEQ + 1),
-                    payload: &segment,
-                    ..SEND_TEMPL
-                }
-            );
-            recv!(
-                s,
-                [TcpRepr {
-                    seq_number: LOCAL_SEQ + 1,
-                    ack_number: Some(REMOTE_SEQ + 1 + offset + 500),
-                    window_len: 3500,
-                    ..RECV_TEMPL
-                }]
-            );
-            s.view()
-                .recv(|data| {
-                    assert_eq!(data.len(), 500);
-                    assert_eq!(data, segment.as_slice());
-                    (500, ())
-                })
-                .unwrap();
-        }
-        assert_eq!(s.remote_last_win, 3500);
-        (s, segment)
-    }
-
-    #[test]
-    fn test_established_rfc2018_cases() {
-        // This test case verifies the exact scenarios described on pages 8-9 of RFC 2018. Please
-        // ensure its behavior does not deviate from those scenarios.
-
-        let (mut s, segment) = setup_rfc2018_cases();
-        // RFC 2018:
-        //
-        // Case 2: The first segment is dropped but the remaining 7 are received.
-        //
-        // Upon receiving each of the last seven packets, the data receiver will return a TCP ACK
-        // segment that acknowledges sequence number 5000 and contains a SACK option specifying one
-        // block of queued data:
-        //
-        //   Triggering   ACK      Left Edge  Right Edge
-        //   Segment
-        //
-        //   5000         (lost)
-        //   5500         5000     5500       6000
-        //   6000         5000     5500       6500
-        //   6500         5000     5500       7000
-        //   7000         5000     5500       7500
-        //   7500         5000     5500       8000
-        //   8000         5000     5500       8500
-        //   8500         5000     5500       9000
-        //
-        for offset in (500..3500).step_by(500) {
-            send!(
-                s,
-                TcpRepr {
-                    seq_number: REMOTE_SEQ + 1 + offset + 5000,
-                    ack_number: Some(LOCAL_SEQ + 1),
-                    payload: &segment,
-                    ..SEND_TEMPL
-                },
-                Some(TcpRepr {
-                    seq_number: LOCAL_SEQ + 1,
-                    ack_number: Some(REMOTE_SEQ + 1 + 5000),
-                    window_len: 4000,
-                    sack_ranges: [
-                        Some((
-                            REMOTE_SEQ.0 as u32 + 1 + 5500,
-                            REMOTE_SEQ.0 as u32 + 1 + 5500 + offset as u32
-                        )),
-                        None,
-                        None
-                    ],
-                    ..RECV_TEMPL
-                })
-            );
-        }
-    }
-
+    /// Case:
+    /// The remote sequence space straddles the u32 wrap and two islands
+    /// are created. One straddling the boundary and another past it.
+    ///
+    /// Outcome:
+    /// The SACK ranges are reported correctly with no overflow.
     #[test]
     fn test_established_sack_no_overflow_on_near_max_seqnumber() {
         let mut s = socket_established();
@@ -4933,21 +5005,38 @@ mod test {
         s.remote_seq_no = TcpSeqNumber(-4);
         s.remote_last_ack = Some(TcpSeqNumber(-4));
 
-        // Send an out-of-order segment 10 bytes past the expected sequence,
-        // creating a 10-byte hole at the front of the assembler.
+        // Create first island - [-2..2) - and SACK reports it
         send!(
             s,
             TcpRepr {
-                seq_number: TcpSeqNumber(-4 + 10),
+                seq_number: TcpSeqNumber(-2),
                 ack_number: Some(LOCAL_SEQ + 1),
-                payload: &b"AAAAAAAAAA"[..],
+                payload: &b"AAAA"[..],
                 ..SEND_TEMPL
             },
             Some(TcpRepr {
                 seq_number: LOCAL_SEQ + 1,
                 ack_number: Some(TcpSeqNumber(-4)),
                 window_len: 64,
-                sack_ranges: [Some(((-4_i32 + 10) as u32, (-4_i32 + 20) as u32,)), None, None,],
+                sack_ranges: [Some((u32::MAX - 1, 2)), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Create second island - [6..10) - and SACK reports both
+        send!(
+            s,
+            TcpRepr {
+                seq_number: TcpSeqNumber(6),
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &b"BBBB"[..],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(TcpSeqNumber(-4)),
+                window_len: 64,
+                sack_ranges: [Some((6, 10)), Some((u32::MAX - 1, 2)), None],
                 ..RECV_TEMPL
             })
         );
@@ -9982,6 +10071,1082 @@ mod test {
                 ack_number: Some(REMOTE_SEQ + 1),
                 payload: &b"abcdef"[..],
                 timestamp: None,
+                ..RECV_TEMPL
+            }]
+        );
+    }
+
+    // =========================================================================================//
+    // Tests for Selective Acknowledgements
+    // =========================================================================================//
+
+    /// Creates a SACK range from segment's left and right edges.
+    fn block(left: usize, right: usize) -> Option<(u32, u32)> {
+        Some(((REMOTE_SEQ + 1 + left).0 as u32, (REMOTE_SEQ + 1 + right).0 as u32))
+    }
+
+    /// Sets up a socket to the initial conditions used in the RFC 2018 test cases.
+    ///
+    /// RFC 2018: Assume the left window edge is 5000 and that the data transmitter sends [...]
+    /// segments, each containing 500 data bytes.
+    fn setup_rfc2018_cases() -> (TestSocket, Vec<u8>) {
+        setup_rfc2018_cases_with_rx_buffer(4000)
+    }
+
+    /// As `setup_rfc2018_cases()`, with the receive buffer size chosen by the caller.
+    fn setup_rfc2018_cases_with_rx_buffer(rx_len: usize) -> (TestSocket, Vec<u8>) {
+        let mut s = socket_established_with_buffer_sizes(4000, rx_len);
+        s.remote_has_sack = true;
+
+        // The window advertised while one 500 byte segment sits undrained.
+        let win = (rx_len - 500) as u16;
+
+        // create a segment that is 500 bytes long
+        let mut segment: Vec<u8> = Vec::with_capacity(500);
+
+        // move the last ack to 5000 by sending ten of them
+        for _ in 0..50 {
+            segment.extend_from_slice(b"abcdefghij")
+        }
+        for offset in (0..5000).step_by(500) {
+            send!(
+                s,
+                TcpRepr {
+                    seq_number: REMOTE_SEQ + 1 + offset,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    payload: &segment,
+                    ..SEND_TEMPL
+                }
+            );
+            recv!(
+                s,
+                [TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1 + offset + 500),
+                    window_len: win,
+                    ..RECV_TEMPL
+                }]
+            );
+            s.view()
+                .recv(|data| {
+                    assert_eq!(data.len(), 500);
+                    assert_eq!(data, segment.as_slice());
+                    (500, ())
+                })
+                .unwrap();
+        }
+        assert_eq!(s.remote_last_win, win);
+        (s, segment)
+    }
+
+    /// Case:
+    /// Following RFC 2018 setup, the first segment is dropped but the
+    /// remaining 7 are received.
+    ///
+    /// Outcome:
+    /// Upon receiving each of the last seven packets, the data receiver will
+    /// return a TCP ACK segment that acknowledges sequence number 5000 and
+    /// contains a SACK option specifying one block of queued data.
+    ///
+    ///                             +---------------+----------------+
+    ///                             |          First Block           |
+    /// +-------------+-------------+---------------+----------------+
+    /// |    Segment  |     ACK     |   Left Edge   |   Right Edge   |
+    /// +-------------+-------------+---------------+----------------|
+    /// |    5000     |    (lost)   |               |                |
+    /// |    5500     |    5000     |     5500      |      6000      |
+    /// |    6000     |    5000     |     5500      |      6500      |
+    /// |    6500     |    5000     |     5500      |      7000      |
+    /// |    7000     |    5000     |     5500      |      7500      |
+    /// |    7500     |    5000     |     5500      |      8000      |
+    /// |    8000     |    5000     |     5500      |      8500      |
+    /// |    8500     |    5000     |     5500      |      9000      |
+    /// +-------------+-------------+---------------+----------------+
+    #[test]
+    fn test_sack_rfc2018_case_2() {
+        let (mut s, segment) = setup_rfc2018_cases();
+
+        for offset in (500..3500).step_by(500) {
+            send!(
+                s,
+                TcpRepr {
+                    seq_number: REMOTE_SEQ + 1 + offset + 5000,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    payload: &segment,
+                    ..SEND_TEMPL
+                },
+                Some(TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1 + 5000),
+                    window_len: 4000,
+                    sack_ranges: [block(5500, 5500 + offset), None, None],
+                    ..RECV_TEMPL
+                })
+            );
+        }
+    }
+
+    /// Case:
+    /// Following RFC 2018 setup, the 2nd, 4th, 6th, and 8th (last) segments
+    /// are dropped.
+    ///
+    /// Outcome:
+    /// The data receiver ACKs the first packet normally.  The third, fifth, and
+    /// seventh packets trigger SACK options.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |    5000    |   5500   |        |        |        |        |        |        |
+    /// |    5500    |   (lost) |        |        |        |        |        |        |
+    /// |    6000    |   5500   |  6000  |  6500  |        |        |        |        |
+    /// |    6500    |   (lost) |        |        |        |        |        |        |
+    /// |    7000    |   5500   |  7000  |  7500  |  6000  |  6500  |        |        |
+    /// |    7500    |   (lost) |        |        |        |        |        |        |
+    /// |    8000    |   5500   |  8000  |  8500  |  7000  |  7500  |  6000  |  6500  |
+    /// |    8500    |   (lost) |        |        |        |        |        |        |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    ///
+    /// Now, the 4th, 2nd and  6th (not specified in RFC test case) s egments are
+    /// received:
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |    6500    |   5500   |  6000  |  7500  |  8000  |  8500  |        |        |
+    /// |    5500    |   7500   |  8000  |  8500  |        |        |        |        |
+    /// |    7500    |   8500   |        |        |        |        |        |        |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    #[test]
+    fn test_sack_rfc2018_case_3() {
+        let (mut s, segment) = setup_rfc2018_cases();
+
+        // Segment 5000 advances the left edge.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 5000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 3500,
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            }]
+        );
+
+        // 5500 is lost. Segment 6000 opens an island. One SACK block should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 3500,
+                sack_ranges: [block(6000, 6500), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // 6500 is lost. Segment 7000 opens a second island. Two SACK blocks should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 7000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 3500,
+                sack_ranges: [block(7000, 7500), block(6000, 6500), None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // 7500 is lost. Segment 8000 opens a third island. Three SACK blocks should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 8000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 3500,
+                sack_ranges: [block(8000, 8500), block(7000, 7500), block(6000, 6500)],
+                ..RECV_TEMPL
+            })
+        );
+
+        // 6500 is received out of order. SACK ranges merge. Two SACK blocks should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 3500,
+                sack_ranges: [block(6000, 7500), block(8000, 8500), None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // 5500 is received out of order. Window advances. One SACK block should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 5500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 7500),
+                window_len: 1500,
+                sack_ranges: [block(8000, 8500), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // 7500 is received. Window advances. No SACK blocks should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 7500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 8500),
+                window_len: 500,
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        assert_eq!(s.local_sack_history, [None, None, None]);
+    }
+
+    /// Case:
+    /// Following RFC 2018 setup, the 2nd, 4th and 6th segments are dropped. The
+    ///  network reorders the survivors and then the remote transmits a pure ACK.
+    ///
+    /// Outcome:
+    /// The data receiver ACKs the first segment normally. Each later segment
+    /// triggers a SACK option and leads with its own block.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |    5000    |   5500   |        |        |        |        |        |        |
+    /// |    5500    |   (lost) |        |        |        |        |        |        |
+    /// |    8000    |   5500   |  8000  |  8500  |        |        |        |        |
+    /// |    8500    |   5500   |  8000  |  9000  |        |        |        |        |
+    /// |    7000    |   5500   |  7000  |  7500  |  8000  |  9000  |        |        |
+    /// |    6000    |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    ///
+    /// A pure ACK from the transmitter now arrives. It carries no data and  has a
+    /// sequence number of 9000, right on the edge of the data held by the assembler.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// | (pure ACK) |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    #[test]
+    fn test_sack_not_affected_by_pure_ack() {
+        let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(5000);
+
+        // Segment 5000 advances the left edge.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 5000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            }]
+        );
+
+        // Segment 8000 arrives early and opens an island.
+        // One SACK block should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 8000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(8000, 8500), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Segment 8500 arrives early and increases the island width.
+        // One SACK block should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 8500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(8000, 9000), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Segment 7000 opens a second island.
+        // Two SACK blocks should be reported.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 7000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(7000, 7500), block(8000, 9000), None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Segment 6000 arrives and opens an island.
+        // Three SACK blocks should be reported, with [6000, 6500) being first.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(6000, 6500), block(7000, 7500), block(8000, 9000)],
+                ..RECV_TEMPL
+            })
+        );
+
+        // A pure ACK carrying the transmitter's snd_nxt of 9000. No payload.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 9000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[],
+                ..SEND_TEMPL
+            }
+        );
+
+        // Transmitted data will contain the SACK ranges.
+        // SACK ordering should remain the same as before, unaffected by the pure ACK.
+        s.view().send_slice(b"x").unwrap();
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                payload: b"x",
+                sack_ranges: [block(6000, 6500), block(7000, 7500), block(8000, 9000)],
+                ..RECV_TEMPL
+            }]
+        );
+    }
+
+    /// Case:
+    /// Following RFC 2018 setup, the 2nd, 4th and 6th segments are dropped. The
+    /// network reorders the survivors and then a reordered pure ACK (SEQ < 9000) is
+    /// delivered.
+    ///
+    ///
+    /// Outcome:
+    /// The data receiver ACKs the first segment normally. Each later segment
+    /// triggers a SACK option and leads with its own block.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |    5000    |   5500   |        |        |        |        |        |        |
+    /// |    5500    |   (lost) |        |        |        |        |        |        |
+    /// |    8000    |   5500   |  8000  |  8500  |        |        |        |        |
+    /// |    8500    |   5500   |  8000  |  9000  |        |        |        |        |
+    /// |    7000    |   5500   |  7000  |  7500  |  8000  |  9000  |        |        |
+    /// |    6000    |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    ///
+    /// A reordered pure ACK arrives, with a sequence number inside one of the ranges
+    /// held by the assembler.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// | (pure ACK) |   5500   |  6000  |  6500  |  7000  |  7500  |  8000  |  9000  |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    #[test]
+    fn test_sack_not_affected_by_reordered_pure_ack() {
+        let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(5000);
+
+        // Segment 5000 advances the left edge.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 5000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            }]
+        );
+
+        // Segment 8000 arrives early and opens an island.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 8000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(8000, 8500), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Segment 8500 arrives early and increases the island width.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 8500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(8000, 9000), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Segment 7000 opens a second island.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 7000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(7000, 7500), block(8000, 9000), None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Segment 6000 opens a third island and becomes the last data segment.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                sack_ranges: [block(6000, 6500), block(7000, 7500), block(8000, 9000)],
+                ..RECV_TEMPL
+            })
+        );
+
+        // The reordered pure ACK, carrying the snd_nxt of 8500 it was sent with.
+        // No payload.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 8500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[],
+                ..SEND_TEMPL
+            }
+        );
+
+        // Transmitted data will contain the SACK ranges.
+        // SACK ordering should remain the same as before, unaffected by the pure ACK.
+        s.view().send_slice(b"x").unwrap();
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 4500,
+                payload: b"x",
+                sack_ranges: [block(6000, 6500), block(7000, 7500), block(8000, 9000)],
+                ..RECV_TEMPL
+            }]
+        );
+    }
+
+    /// Case:
+    /// One island is held, so every outgoing ACK carries one SACK block. The socket
+    /// then gets one MSS of data top send.
+    ///
+    /// Outcome:
+    /// The data should be split into two segments, due to the length of the options.
+    /// One full segment should be sent, and another carrying the remainder. With the
+    /// option length being 12 - TS + SACK (one block) - the remainder should also
+    /// be 12.
+    #[test]
+    fn test_sack_emitted_on_data_segments() {
+        const REMOTE_MSS: usize = 128;
+        const ONE_BLOCK_OPTS: usize = 12;
+        const SEG: usize = REMOTE_MSS - ONE_BLOCK_OPTS;
+
+        let mut s = socket_established_with_buffer_sizes(SEG * 2, 1024);
+        s.remote_has_sack = true;
+        s.remote_mss = REMOTE_MSS;
+        s.remote_win_len = 9999;
+        s.view().set_nagle_enabled(false);
+
+        //  Open an island 100 bytes past the left edge
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 100,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[b'a'; 100],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1),
+                window_len: 1024,
+                sack_ranges: [block(100, 200), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // One MSS of data should take two segments, due to effective MSS shrinkage from option length.
+        s.view().send_slice(&[b'z'; REMOTE_MSS]).unwrap();
+        recv!(
+            s,
+            [
+                TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1),
+                    window_len: 1024,
+                    payload: &[b'z'; REMOTE_MSS - ONE_BLOCK_OPTS],
+                    sack_ranges: [block(100, 200), None, None],
+                    ..RECV_TEMPL
+                },
+                TcpRepr {
+                    seq_number: LOCAL_SEQ + 1 + (REMOTE_MSS - ONE_BLOCK_OPTS),
+                    ack_number: Some(REMOTE_SEQ + 1),
+                    window_len: 1024,
+                    payload: &[b'z'; ONE_BLOCK_OPTS],
+                    sack_ranges: [block(100, 200), None, None],
+                    ..RECV_TEMPL
+                }
+            ]
+        );
+    }
+
+    /// Case:
+    /// One island is held when the remote then closes its window. Data queues at the
+    /// socket and a zero window probe is sent.
+    ///
+    /// Outcome:
+    /// The zerow window probe carries the previously annoucned SACK range.
+    #[test]
+    fn test_sack_emitted_on_zero_window_probe() {
+        let mut s = socket_established_with_buffer_sizes(64, 128);
+        s.remote_has_sack = true;
+
+        // A segment 20 bytes past the left edge opens one island
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 20,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[b'a'; 10],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1),
+                window_len: 128,
+                sack_ranges: [block(20, 30), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Queued data plus a closed remote window arms the probe timer
+        s.view().send_slice(b"abcdef").unwrap();
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1,
+                ack_number: Some(LOCAL_SEQ + 1),
+                window_len: 0,
+                ..SEND_TEMPL
+            }
+        );
+        assert!(s.timer.is_zero_window_probe());
+
+        // Timer triggers and ZWP triggers containing the SACK ranges
+        recv_nothing!(s, time 999);
+        recv!(
+            s,
+            time 1000,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1),
+                window_len: 128,
+                payload: &b"a"[..],
+                sack_ranges: [block(20, 30), None, None],
+                ..RECV_TEMPL
+            }]
+        );
+    }
+
+    /// Case:
+    /// Fill a 128 byte window with 96 contiguous bytes and a 10 byte out-of-order
+    /// segment. Then, the application drains the buffer.
+    ///
+    /// Outcome:
+    /// The buffer drain should cause a window update to be sent. This update should
+    /// contain a SACK block and the window advertised should not include the bytes
+    /// from the out-of-order segment.
+    #[test]
+    fn test_sack_emitted_on_window_update() {
+        let mut s = socket_established_with_buffer_sizes(64, 128);
+        s.remote_has_sack = true;
+
+        // Contiguous data to advance left edge and fill the buffer
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[b'a'; 96],
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 96),
+                window_len: 32,
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            }]
+        );
+
+        // 10 bytes, out-of-order, to create an island in the assembler
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 106,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[b'b'; 10],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 96),
+                window_len: 32,
+                sack_ranges: [block(106, 116), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // Receiving the data should trigger a window update
+        s.view().recv(|data| (data.len(), ())).unwrap();
+
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 96),
+                window_len: 128,
+                sack_ranges: [block(106, 116), None, None],
+                ..RECV_TEMPL
+            }]
+        );
+    }
+
+    /// Case:
+    /// Four islands arrive in reverse order: 8th, 6th, 4th then 2nd. Then, segment 1 is
+    /// received.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +--------------+--------+--------+--------+--------+--------+--------+--------+
+    /// |    Segment   |   ACK  |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +--------------+--------+--------+--------+--------+--------+--------+--------+
+    /// |     8500     |  5000  |  8500  |  9000  |        |        |        |        |
+    /// |     7500     |  5000  |  7500  |  8000  |  8500  |  9000  |        |        |
+    /// |     6500     |  5000  |  6500  |  7000  |  7500  |  8000  |  8500  |  9000  |
+    /// |     5500     |  5000  |  5500  |  6000  |  6500  |  7000  |  7500  |  8000  |
+    /// |     5000     |  6000  |  6500  |  7000  |  7500  |  8000  |  8500  |  9000  |
+    /// +--------------+--------+--------+--------+--------+--------+--------+--------+
+    ///
+    /// Outcome:
+    /// Four islans shuoldbe held within the assembler, but only three blocks reported
+    /// in the order that they were received. When segment 1 is received and advances
+    /// the left edge, SACK ranges should now contain that fourth island.
+    #[test]
+    fn test_sack_reports_three_of_four_islands() {
+        let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(5000);
+
+        // Four islands in reverse order
+        for (offset, expected) in [
+            (8500, [block(8500, 9000), None, None]),
+            (7500, [block(7500, 8000), block(8500, 9000), None]),
+            (6500, [block(6500, 7000), block(7500, 8000), block(8500, 9000)]),
+            (5500, [block(5500, 6000), block(6500, 7000), block(7500, 8000)]),
+        ] {
+            send!(
+                s,
+                TcpRepr {
+                    seq_number: REMOTE_SEQ + 1 + offset,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    payload: &segment,
+                    ..SEND_TEMPL
+                },
+                Some(TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1 + 5000),
+                    window_len: 5000,
+                    sack_ranges: expected,
+                    ..RECV_TEMPL
+                })
+            );
+        }
+
+        assert_eq!(s.assembler.iter_data().count(), 4);
+
+        // Advancing the left edge should remove one island and let another be reported:w
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 5000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 6000),
+                window_len: 4000,
+                sack_ranges: [block(6500, 7000), block(7500, 8000), block(8500, 9000)],
+                ..RECV_TEMPL
+            })
+        );
+    }
+
+    /// RFC 2018 defines the block edges as a half-open range:
+    ///
+    /// - Left Edge of Block: the first sequence number of this block.
+    /// - Right Edge of Block: the sequence number immediately following the last
+    ///   sequence number of this block.
+    ///
+    /// So the right edge names the first byte the receiver does NOT hold.
+    ///
+    /// Case:
+    /// Two segments arrive with a gap of exactly one byte between them, at 6500.
+    /// The one byte then arrives and closes the gap.
+    ///
+    /// Outcome:
+    /// The first two arrivals must stay two separate blocks. A right edge of 6500
+    /// that meant "6500 is held" would leave no gap, and the two would report as
+    /// one block. The single byte at 6500 then merges them into one.
+    ///
+    ///                          +-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |
+    /// +--------------+--------+--------+--------+--------+--------+
+    /// |    Segment   |   ACK  |  Left  |  Right |  Left  |  Right |
+    /// +--------------+--------+--------+--------+--------+--------+
+    /// |  6000..6500  |  5000  |  6000  |  6500  |        |        |
+    /// |  6501..7001  |  5000  |  6501  |  7001  |  6000  |  6500  |
+    /// |  6500..6501  |  5000  |  6000  |  7001  |        |        |
+    /// +--------------+--------+--------+--------+--------+--------+
+    #[test]
+    fn test_sack_is_an_exclusive_range() {
+        let (mut s, segment) = setup_rfc2018_cases();
+
+        // 500 bytes at 6000. The right edge is 6500, one past the last byte held.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5000),
+                window_len: 4000,
+                sack_ranges: [block(6000, 6500), None, None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // 500 bytes at 6501, leaving exactly one byte missing at 6500. Two blocks,
+        // so 6500 is confirmed absent from the first one.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6501,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5000),
+                window_len: 4000,
+                sack_ranges: [block(6501, 7001), block(6000, 6500), None],
+                ..RECV_TEMPL
+            })
+        );
+
+        // The one missing byte. Both islands become one, which is only possible if
+        // 6500 was the gap and not part of either block.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 6500,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment[..1],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5000),
+                window_len: 4000,
+                sack_ranges: [block(6000, 7001), None, None],
+                ..RECV_TEMPL
+            })
+        );
+    }
+
+    /// Case:
+    /// Following from RFC 2018 setup, every second segment is dropped, so each
+    ///  arrival opens a new island. The assembler holds at most  `ASSEMBLER_MAX_SEGMENT_COUNT`
+    /// islands, which `src/lib.rs` pins to 4 for test builds.
+    ///
+    /// Outcome:
+    /// The data receiver ACKs the first segment normally. Each later arrival opens
+    /// an island and leads with its own block. Only three blocks fit, so the
+    /// island at 6000 stops being reported once a fourth one opens.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |    5000    |   5500   |        |        |        |        |        |        |
+    /// |    5500    |   (lost) |        |        |        |        |        |        |
+    /// |    6000    |   5500   |  6000  |  6500  |        |        |        |        |
+    /// |    6500    |   (lost) |        |        |        |        |        |        |
+    /// |    7000    |   5500   |  7000  |  7500  |  6000  |  6500  |        |        |
+    /// |    7500    |   (lost) |        |        |        |        |        |        |
+    /// |    8000    |   5500   |  8000  |  8500  |  7000  |  7500  |  6000  |  6500  |
+    /// |    8500    |   (lost) |        |        |        |        |        |        |
+    /// |    9000    |   5500   |  9000  |  9500  |  8000  |  8500  |  7000  |  7500  |
+    /// |    9500    |   (lost) |        |        |        |        |        |        |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    ///
+    /// The assembler now holds 4 islands and is full. Segment 10000 would open a
+    /// fifth, so the assembler rejects it with `TooManyHolesError` and the payload
+    /// is discarded.
+    ///
+    ///                          +-----------------+-----------------+-----------------+
+    ///                          |   First Block   |  Second Block   |   Third Block   |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   Segment  |    ACK   |  Left  |  Right |  Left  |  Right |  Left  |  Right |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    /// |   10000    | (no ACK) |        |        |        |        |        |        |
+    /// |  transmit  |   5500   |  9000  |  9500  |  8000  |  8500  |  7000  |  7500  |
+    /// +------------+----------+--------+--------+--------+--------+--------+--------+
+    #[test]
+    fn test_sack_works_when_assembler_rejects_segment() {
+        // The window must stay wide enough that segment 10000 is still inside it,
+        // so the assembler turns it away rather than the window check.
+        let (mut s, segment) = setup_rfc2018_cases_with_rx_buffer(6000);
+
+        // Segment 5000 advances the left edge.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + 5000,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 5500,
+                sack_ranges: [None, None, None],
+                ..RECV_TEMPL
+            }]
+        );
+
+        // Every second segment is lost, so each arrival opens a fresh island.
+        // The assembler is filled to capacity.
+        for i in 0..4 {
+            let offset = 6000 + i * 1000;
+            send!(
+                s,
+                TcpRepr {
+                    seq_number: REMOTE_SEQ + 1 + offset,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    payload: &segment,
+                    ..SEND_TEMPL
+                },
+                Some(TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                    window_len: 5500,
+                    sack_ranges: [
+                        block(offset, offset + 500),
+                        (i >= 1).then(|| block(offset - 1000, offset - 500)).flatten(),
+                        (i >= 2).then(|| block(offset - 2000, offset - 1500)).flatten(),
+                    ],
+                    ..RECV_TEMPL
+                })
+            );
+        }
+
+        let islands_before = s.assembler.iter_data().count();
+        assert_eq!(islands_before, 4);
+
+        let blocks_before = s.local_sack_history;
+
+        // The assembler should reject this segment with `TooManyHolesError`
+        let rejected = 10000;
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1 + rejected,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &segment,
+                ..SEND_TEMPL
+            }
+        );
+
+        // Assembler must not hold the segment
+        assert_eq!(s.assembler.iter_data().count(), islands_before);
+        assert!(!s.assembler.iter_data().any(|(l, _)| l == rejected - 5500));
+
+        // The SACK history should not have changed
+        assert_eq!(s.local_sack_history, blocks_before);
+
+        // Transmitted data will contain the SACK ranges.
+        // SACK ordering on the wire should remain as before, unaffected by the rejected segment.
+        s.view().send_slice(b"x").unwrap();
+        recv!(
+            s,
+            [TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 1 + 5500),
+                window_len: 5500,
+                payload: b"x",
+                sack_ranges: blocks_before.map(|b| b.map(|(l, r)| (l.0 as u32, r.0 as u32))),
                 ..RECV_TEMPL
             }]
         );

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -752,21 +752,26 @@ impl<'d> TcpSocketState<'d> {
             self.icmp_error = None;
         }
         self.local_seq_no = TcpSeqNumber::default();
+        self.local_rx_last_seq = None;
+        self.local_rx_last_ack = None;
+        self.local_rx_dup_acks = 0;
+        self.pending_fast_retransmit = false;
         self.remote_seq_no = TcpSeqNumber::default();
         self.remote_last_seq = TcpSeqNumber::default();
         self.remote_last_ack = None;
         self.remote_last_win = 0;
         self.remote_win_len = 0;
         self.remote_win_scale = None;
+        self.remote_has_sack = false;
         self.remote_win_shift = rx_cap_log2.saturating_sub(16) as u8;
         self.remote_has_sack = false;
         self.remote_mss = DEFAULT_MSS;
         self.ip_mtu = DEFAULT_IP_MTU;
         self.remote_last_ts = None;
-        self.local_rx_last_ack = None;
-        self.local_rx_last_seq = None;
-        self.local_rx_dup_acks = 0;
-        self.pending_fast_retransmit = false;
+        #[cfg(feature = "tcp-timestamps")]
+        {
+            self.last_remote_tsval = 0;
+        }
         self.ack_delay_timer = AckDelayTimer::Idle;
         self.challenge_ack_timer = Instant::from_secs(0);
         self.congestion_controller = congestion::Congestion::new();
@@ -4118,6 +4123,8 @@ mod test {
                 max_seg_size: Some(BASE_MSS),
                 window_scale: Some(0),
                 sack_permitted: false,
+                #[cfg(feature = "tcp-timestamps")]
+                timestamp: Some(TcpTimestampRepr::new(0, 0)),
                 ..RECV_TEMPL
             }]
         );
@@ -6712,6 +6719,32 @@ mod test {
             payload:    &b"abcdef"[..],
             ..RECV_TEMPL
         }));
+    }
+
+    #[test]
+    fn test_reset_clears_connection_state() {
+        let mut s = socket_established();
+        s.remote_has_sack = true;
+        s.local_rx_last_seq = Some(TcpSeqNumber(42));
+        s.local_rx_last_ack = Some(TcpSeqNumber(42));
+        s.local_rx_dup_acks = 2;
+        s.pending_fast_retransmit = true;
+        #[cfg(feature = "tcp-timestamps")]
+        {
+            s.last_remote_tsval = 7;
+        }
+
+        s.reset();
+
+        assert!(!s.remote_has_sack);
+        assert_eq!(s.local_rx_last_seq, None);
+        assert_eq!(s.local_rx_last_ack, None);
+        assert_eq!(s.local_rx_dup_acks, 0);
+        assert!(!s.pending_fast_retransmit);
+        #[cfg(feature = "tcp-timestamps")]
+        {
+            assert_eq!(s.last_remote_tsval, 0);
+        }
     }
 
     #[cfg(feature = "tcp-reno")]

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -915,8 +915,6 @@ impl<'d> TcpSocketState<'d> {
         // segment.
         #[cfg(feature = "tcp-sack")]
         if self.remote_has_sack {
-            debug!("sending sACK option with current assembler ranges");
-
             let ack = reply_repr.ack_number.unwrap_or(TcpSeqNumber(0));
             reply_repr.sack_ranges = self.generate_sack_ranges(ack);
         }
@@ -1769,6 +1767,8 @@ impl<'d> TcpSocketState<'d> {
             self.local_sack_history = [None, None, None];
             return [None, None, None];
         }
+
+        debug!("sending SACK option with current assembler ranges");
 
         let mut blocks = [None, None, None];
         let mut n = 0;

--- a/src/tcp/repr.rs
+++ b/src/tcp/repr.rs
@@ -22,7 +22,9 @@ pub(crate) struct TcpRepr<'a> {
     pub window_len: u16,
     pub window_scale: Option<u8>,
     pub max_seg_size: Option<u16>,
+    #[cfg(feature = "tcp-sack")]
     pub sack_permitted: bool,
+    #[cfg(feature = "tcp-sack")]
     pub sack_ranges: [Option<(u32, u32)>; 3],
     #[cfg(feature = "tcp-timestamps")]
     pub timestamp: Option<TcpTimestampRepr>,
@@ -88,7 +90,9 @@ impl<'a> TcpRepr<'a> {
         let mut max_seg_size = None;
         let mut window_scale = None;
         let mut options = packet.options();
+        #[cfg(feature = "tcp-sack")]
         let mut sack_permitted = false;
+        #[cfg(feature = "tcp-sack")]
         let mut sack_ranges = [None, None, None];
         #[cfg(feature = "tcp-timestamps")]
         let mut timestamp = None;
@@ -116,7 +120,9 @@ impl<'a> TcpRepr<'a> {
                         Some(value)
                     };
                 }
+                #[cfg(feature = "tcp-sack")]
                 TcpOption::SackPermitted => sack_permitted = true,
+                #[cfg(feature = "tcp-sack")]
                 TcpOption::SackRange(slice) => sack_ranges = slice,
                 #[cfg(feature = "tcp-timestamps")]
                 TcpOption::TimeStamp { tsval, tsecr } => {
@@ -136,7 +142,9 @@ impl<'a> TcpRepr<'a> {
             window_len: packet.window_len(),
             window_scale,
             max_seg_size,
+            #[cfg(feature = "tcp-sack")]
             sack_permitted,
+            #[cfg(feature = "tcp-sack")]
             sack_ranges,
             #[cfg(feature = "tcp-timestamps")]
             timestamp,
@@ -157,6 +165,7 @@ impl<'a> TcpRepr<'a> {
         if self.window_scale.is_some() {
             length += 3
         }
+        #[cfg(feature = "tcp-sack")]
         if self.sack_permitted {
             length += 2;
         }
@@ -164,9 +173,12 @@ impl<'a> TcpRepr<'a> {
         if self.timestamp.is_some() {
             length += 10;
         }
-        let sack_range_len: usize = self.sack_ranges.iter().map(|o| o.map(|_| 8).unwrap_or(0)).sum();
-        if sack_range_len > 0 {
-            length += sack_range_len + 2;
+        #[cfg(feature = "tcp-sack")]
+        {
+            let sack_range_len: usize = self.sack_ranges.iter().map(|o| o.map(|_| 8).unwrap_or(0)).sum();
+            if sack_range_len > 0 {
+                length += sack_range_len + 2;
+            }
         }
         if !length.is_multiple_of(4) {
             length += 4 - length % 4;
@@ -220,6 +232,7 @@ impl<'a> TcpRepr<'a> {
                 let tmp = options;
                 options = TcpOption::WindowScale(value).emit(tmp);
             }
+            #[cfg(feature = "tcp-sack")]
             if self.sack_permitted {
                 let tmp = options;
                 options = TcpOption::SackPermitted.emit(tmp);
@@ -315,7 +328,9 @@ mod test {
             window_scale: None,
             control: TcpControl::Syn,
             max_seg_size: None,
+            #[cfg(feature = "tcp-sack")]
             sack_permitted: false,
+            #[cfg(feature = "tcp-sack")]
             sack_ranges: [None, None, None],
             #[cfg(feature = "tcp-timestamps")]
             timestamp: None,


### PR DESCRIPTION
This PR is a partial implementation of selective acknowledgements (**SACK**).Current state of SACK is:

> On the sending side, SACK ranges are sent only in response to duplicate data (when process() calls ack_reply()) and only a single SACK range is sent. This range doesn't operate as the RFC suggests and is simply a "here's the earliest missing segment" hint.

> On the receiving side, all SACK ranges are discarded.

This PR implements full data-receiver behaviour ([RFC 2018 - Section 4](https://datatracker.ietf.org/doc/html/rfc2018#section-4)): transmitting SACK ranges on all emitted segments and making full use of the  available SACK blocks that can be sent. I've limited it to three blocks and it would be easy to support four SACK blocks, but I imagine this will nearly always be combined with the timestamp option so there's not much point.

The main two tests from the RFC are implemented, plus a few more checking edge cases and scenarios not discussed in the RFC.

Against Linux TCP through a TAP device, I see these results with SACK enabled and disabled:
```
         ┌────────────┬─────────────┐
         │     throughput delta     |
┌────────┬────────────┬─────────────┐
│ loss % │ 5 ms delay │ 10 ms delay │
├────────┼────────────┼─────────────┤
│ 0      │ +3%        │ +1%         │
├────────┼────────────┼─────────────┤
│ 0.001  │ −0.3%      │ −2%         │
├────────┼────────────┼─────────────┤
│ 0.01   │ −3%        │ −4%         │
├────────┼────────────┼─────────────┤
│ 0.1    │ +0.6%      │ +3%         │
├────────┼────────────┼─────────────┤
│ 1      │ −81%       │ −65%        │
├────────┼────────────┼─────────────┤
│ 2      │ −60%       │ −93%        │
├────────┼────────────┼─────────────┤
│ 5      │ −59%       │ −54%*       │
└────────┴────────────┴─────────────┘

*sack-disabled run timed out so true difference is greater
```

Overall, significant performance gains as loss is introduced. The same tests run against the smoltcp stack show 0 difference in throughput (due to the SACK ranges not being used) so there doesn't seem to be any regressions.

Next steps will be to implement the other half (receiving SACK ranges and acting on them). The work is done, just in need of tidying up. Once this is merged I'll follow up with that, plus DSACK and PLPMTUD too.