### PR TITLE
slaac: solicit routers again when the link comes back

### DIFF
--- a/src/iface/dhcpv4.rs
+++ b/src/iface/dhcpv4.rs
@@ -781,12 +781,14 @@ impl IfaceState<'_> {
     pub(crate) fn dhcpv4_reset(&mut self, inner: &mut StackInner) {
         let Some(client) = &mut self.dhcpv4 else { return };
         trace!("DHCP reset");
-        let old = core::mem::replace(
-            &mut client.state,
-            ClientState::Discovering(DiscoverState {
-                retry_at: Instant::from_millis(0),
-            }),
-        );
+        // A client that was already discovering keeps its backoff, so a flapping link
+        // cannot put a DISCOVER on the wire per flap. One that had a lease has just lost
+        // it, so it looks again straight away.
+        let retry_at = match &client.state {
+            ClientState::Discovering(state) => state.retry_at,
+            _ => Instant::from_millis(0),
+        };
+        let old = core::mem::replace(&mut client.state, ClientState::Discovering(DiscoverState { retry_at }));
         if let ClientState::Renewing(state) = old {
             self.dhcpv4_apply(inner, None, Some(&state.lease));
         }
@@ -851,9 +853,10 @@ mod test {
 
     use super::*;
     use crate::driver::Checksum;
+    use crate::driver::LinkState;
     use crate::iface::{IfaceHandle, Medium};
     use crate::stack::Stack;
-    use crate::test_device::{Queue, Sent, TestDevice};
+    use crate::test_device::{Link, Queue, Sent, TestDevice};
     use crate::wire::{
         ArpPacket, DhcpOpCode, ETHERNET_HEADER_LEN, EthernetAddress, EthernetFrame, EthernetProtocol, HardwareAddress,
         IpProtocol, Ipv4Packet,
@@ -869,13 +872,19 @@ mod test {
 
     /// A stack with one Ethernet interface, no addresses, DHCP on.
     fn test_stack() -> (Stack<'static>, Queue, Sent) {
+        let (stack, rx, tx, _link) = test_stack_with_checksum(ChecksumCapabilities::default());
+        (stack, rx, tx)
+    }
+
+    /// [`test_stack`], also handing out control of the link state the device reports.
+    fn test_stack_with_link() -> (Stack<'static>, Queue, Sent, Link) {
         test_stack_with_checksum(ChecksumCapabilities::default())
     }
 
     /// [`test_stack`], with a device that claims to handle the given checksums itself.
-    fn test_stack_with_checksum(checksum: ChecksumCapabilities) -> (Stack<'static>, Queue, Sent) {
+    fn test_stack_with_checksum(checksum: ChecksumCapabilities) -> (Stack<'static>, Queue, Sent, Link) {
         let driver = TestDevice::new(Medium::Ethernet).with_checksum(checksum);
-        let (rx, tx) = (driver.rx.clone(), driver.tx.clone());
+        let (rx, tx, link) = (driver.rx.clone(), driver.tx.clone(), driver.link.clone());
         let mut stack = Stack::new(1);
         let handle = driver.install(&mut stack, HardwareAddress::Ethernet(OUR_HW));
         assert_eq!(handle, IFACE);
@@ -884,7 +893,7 @@ mod test {
         stack.poll(at(0));
         tx.borrow_mut().clear();
         stack.iface(handle).set_dhcpv4(Some(DhcpConfig::default()));
-        (stack, rx, tx)
+        (stack, rx, tx, link)
     }
 
     fn at(secs: i64) -> Instant {
@@ -1017,11 +1026,17 @@ mod test {
     /// Drive the client to BOUND: DISCOVER, OFFER, REQUEST, ACK. Returns the stack
     /// with the lease applied at `at(2)`.
     fn bound_stack() -> (Stack<'static>, Queue, Sent) {
+        let (stack, rx, tx, _link) = bound_stack_with(DhcpConfig::default());
+        (stack, rx, tx)
+    }
+
+    /// [`bound_stack`], also handing out control of the link state the device reports.
+    fn bound_stack_with_link() -> (Stack<'static>, Queue, Sent, Link) {
         bound_stack_with(DhcpConfig::default())
     }
 
-    fn bound_stack_with(config: DhcpConfig) -> (Stack<'static>, Queue, Sent) {
-        let (mut stack, rx, tx) = test_stack();
+    fn bound_stack_with(config: DhcpConfig) -> (Stack<'static>, Queue, Sent, Link) {
+        let (mut stack, rx, tx, link) = test_stack_with_link();
         stack.iface(IFACE).set_dhcpv4(Some(config));
 
         // First poll: DISCOVER, from 0.0.0.0 to broadcast.
@@ -1090,7 +1105,7 @@ mod test {
         assert_eq!(route.origin, RouteOrigin::Dhcpv4);
         assert_ne!(stack.iface(IFACE).config_generation(), generation);
 
-        (stack, rx, tx)
+        (stack, rx, tx, link)
     }
 
     /// The interface's IPv4 addresses, leaving out the automatic IPv6 link-local.
@@ -1154,7 +1169,7 @@ mod test {
         // cache entry (60 s) is still fresh.
         let mut config = DhcpConfig::default();
         config.max_lease_duration = Some(Duration::from_secs(60));
-        let (mut stack, rx, tx) = bound_stack_with(config);
+        let (mut stack, rx, tx, _link) = bound_stack_with(config);
 
         // Learn the server's MAC, so the renewal isn't parked on ARP.
         rx.borrow_mut().push_back(arp_request_from_server());
@@ -1280,6 +1295,49 @@ mod test {
         assert_eq!(message_type(&mut sent), DhcpMessageType::Discover);
     }
 
+    /// The same restart runs by itself when the link comes back, so a client that may
+    /// have moved networks does not keep using a lease from the old one.
+    #[test]
+    fn test_restart_on_link_up() {
+        let (mut stack, _rx, tx, link) = bound_stack_with_link();
+        assert!(stack.iface(IFACE).dhcpv4_lease().is_some());
+
+        link.set(LinkState::Down);
+        stack.poll(at(3));
+        link.set(LinkState::Up);
+        stack.poll(at(4));
+
+        assert!(
+            stack.iface(IFACE).dhcpv4_lease().is_none(),
+            "a lease must not survive the link going away"
+        );
+        let mut sent = parse_sent(tx.borrow().last().unwrap());
+        assert_eq!(message_type(&mut sent), DhcpMessageType::Discover);
+    }
+
+    /// Losing the lease means discovering at once, but flapping after that keeps the
+    /// retransmit backoff rather than putting a DISCOVER on the wire per flap.
+    #[test]
+    fn test_link_flap_keeps_discover_backoff() {
+        let (mut stack, _rx, tx, link) = bound_stack_with_link();
+
+        link.set(LinkState::Down);
+        stack.poll(at(3));
+        link.set(LinkState::Up);
+        stack.poll(at(4));
+        let after_first = tx.borrow().len();
+
+        link.set(LinkState::Down);
+        stack.poll(at(5));
+        link.set(LinkState::Up);
+        stack.poll(at(6));
+        assert_eq!(
+            tx.borrow().len(),
+            after_first,
+            "a flapping link must not outpace the DISCOVER backoff"
+        );
+    }
+
     #[test]
     fn test_extra_options() {
         let (mut stack, _rx, tx) = test_stack();
@@ -1360,7 +1418,7 @@ mod test {
         let mut caps = ChecksumCapabilities::default();
         caps.ipv4 = Checksum::None;
         caps.udp = Checksum::None;
-        let (mut stack, _rx, tx) = test_stack_with_checksum(caps);
+        let (mut stack, _rx, tx, _link) = test_stack_with_checksum(caps);
         stack.poll(at(0));
 
         let mut frame = tx.borrow()[0].clone();

--- a/src/iface/dhcpv4.rs
+++ b/src/iface/dhcpv4.rs
@@ -782,8 +782,7 @@ impl IfaceState<'_> {
         let Some(client) = &mut self.dhcpv4 else { return };
         trace!("DHCP reset");
         // A client that was already discovering keeps its backoff, so a flapping link
-        // cannot put a DISCOVER on the wire per flap. One that had a lease has just lost
-        // it, so it looks again straight away.
+        // cannot put a DISCOVER on the wire per flap.
         let retry_at = match &client.state {
             ClientState::Discovering(state) => state.retry_at,
             _ => Instant::from_millis(0),

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -172,12 +172,9 @@ pub(crate) struct IfaceState<'d> {
     pub(crate) dhcpv4: Option<self::dhcpv4::Client>,
     #[cfg(feature = "slaac")]
     pub(crate) slaac: Option<self::slaac::Slaac>,
-    /// Link state as of the previous poll, so a down->up edge can be spotted.
-    ///
-    /// Starts `Down` so the first poll reads as the interface coming up, which is what
-    /// RFC 4861 §6.3.7 solicits on. That edge is a no-op in practice: a fresh
-    /// `Slaac` is already in `Phase::Start` with a full solicitation budget.
-    #[cfg(feature = "slaac")]
+    /// Link state at the previous poll, for spotting the down-to-up edge. Starts
+    /// `Down`, so an interface whose link is already up restarts once, harmlessly.
+    #[cfg(any(feature = "dhcpv4", feature = "slaac"))]
     pub(crate) last_link_state: crate::driver::LinkState,
     #[cfg(feature = "multicast")]
     pub(crate) multicast: crate::multicast::State,
@@ -448,25 +445,14 @@ impl<'d> Iface<'_, 'd> {
         iface.slaac = config.map(self::slaac::Slaac::new);
     }
 
-    /// Ask the network for router advertisements again, keeping the addresses and
-    /// routes already configured.
+    /// Solicit routers again, keeping the addresses and routes already configured.
     ///
-    /// [`Stack::poll`] calls this by itself when the driver reports the link coming back
-    /// up, which is the case RFC 4861 §6.3.7 describes. Call it directly for a driver
-    /// that cannot report link state and so always reads as [`LinkState::Up`], or after
-    /// some other event that means the interface may have moved to a different network.
-    ///
-    /// Solicitations still keep to their normal spacing, so calling this repeatedly does
-    /// not send them any faster.
-    ///
-    /// Does nothing when SLAAC is off. To discard what SLAAC configured rather than
-    /// re-check it, use [`set_slaac`](Self::set_slaac).
-    ///
-    /// [`LinkState::Up`]: crate::driver::LinkState::Up
+    /// [`Stack::poll`] does this when the link comes back up; call it directly for a
+    /// driver that cannot report link state. Does nothing if SLAAC is off.
     #[cfg(feature = "slaac")]
-    pub fn restart_slaac_discovery(&mut self) {
+    pub fn restart_slaac(&mut self) {
         if let Some(slaac) = self.state_mut().slaac.as_mut() {
-            slaac.restart_discovery();
+            slaac.restart();
         }
     }
 
@@ -484,8 +470,8 @@ impl<'d> Iface<'_, 'd> {
 
     /// Drop the DHCPv4 lease, if any, and look for a server again.
     ///
-    /// Call this when the link went down and came back up, so an address on the
-    /// new network is obtained right away. Does nothing if the client is off.
+    /// [`Stack::poll`] does this when the link comes back up; call it directly for a
+    /// driver that cannot report link state. Does nothing if the client is off.
     #[cfg(feature = "dhcpv4")]
     pub fn restart_dhcpv4(&mut self) {
         let Iface { inner, ifaces, index } = self;

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -172,6 +172,13 @@ pub(crate) struct IfaceState<'d> {
     pub(crate) dhcpv4: Option<self::dhcpv4::Client>,
     #[cfg(feature = "slaac")]
     pub(crate) slaac: Option<self::slaac::Slaac>,
+    /// Link state as of the previous poll, so a down->up edge can be spotted.
+    ///
+    /// Starts `Down` so the first poll reads as the interface coming up, which is what
+    /// RFC 4861 §6.3.7 solicits on. That edge is a no-op in practice: a fresh
+    /// `Slaac` is already in `Phase::Start` with a full solicitation budget.
+    #[cfg(feature = "slaac")]
+    pub(crate) last_link_state: crate::driver::LinkState,
     #[cfg(feature = "multicast")]
     pub(crate) multicast: crate::multicast::State,
     #[cfg(any(feature = "ipv4-fragmentation", feature = "sixlowpan-fragmentation"))]
@@ -439,6 +446,28 @@ impl<'d> Iface<'_, 'd> {
         let iface = ifaces.get_mut(*index);
         iface.slaac_reset(inner);
         iface.slaac = config.map(self::slaac::Slaac::new);
+    }
+
+    /// Ask the network for router advertisements again, keeping the addresses and
+    /// routes already configured.
+    ///
+    /// [`Stack::poll`] calls this by itself when the driver reports the link coming back
+    /// up, which is the case RFC 4861 §6.3.7 describes. Call it directly for a driver
+    /// that cannot report link state and so always reads as [`LinkState::Up`], or after
+    /// some other event that means the interface may have moved to a different network.
+    ///
+    /// Solicitations still keep to their normal spacing, so calling this repeatedly does
+    /// not send them any faster.
+    ///
+    /// Does nothing when SLAAC is off. To discard what SLAAC configured rather than
+    /// re-check it, use [`set_slaac`](Self::set_slaac).
+    ///
+    /// [`LinkState::Up`]: crate::driver::LinkState::Up
+    #[cfg(feature = "slaac")]
+    pub fn restart_slaac_discovery(&mut self) {
+        if let Some(slaac) = self.state_mut().slaac.as_mut() {
+            slaac.restart_discovery();
+        }
     }
 
     /// What SLAAC has learned from the routers on the link, or `None` if SLAAC is off.

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -172,8 +172,7 @@ pub(crate) struct IfaceState<'d> {
     pub(crate) dhcpv4: Option<self::dhcpv4::Client>,
     #[cfg(feature = "slaac")]
     pub(crate) slaac: Option<self::slaac::Slaac>,
-    /// Link state at the previous poll, for spotting the down-to-up edge. Starts
-    /// `Down`, so an interface whose link is already up restarts once, harmlessly.
+    /// Link state at the previous poll, for spotting the down-to-up edge.
     #[cfg(any(feature = "dhcpv4", feature = "slaac"))]
     pub(crate) last_link_state: crate::driver::LinkState,
     #[cfg(feature = "multicast")]

--- a/src/iface/slaac.rs
+++ b/src/iface/slaac.rs
@@ -311,9 +311,6 @@ impl Slaac {
     }
 
     /// Solicit again, keeping the prefixes and routes already learned. RFC 4861 §6.3.7.
-    ///
-    /// `retry_rs_at` is left alone so a flapping link cannot solicit faster than
-    /// `RTR_SOLICITATION_INTERVAL`.
     pub(crate) fn restart(&mut self) {
         self.phase = Phase::Start;
         self.num_solicitations = MAX_RTR_SOLICITATIONS;

--- a/src/iface/slaac.rs
+++ b/src/iface/slaac.rs
@@ -310,6 +310,30 @@ impl Slaac {
         matches!(self.phase, Phase::Start | Phase::Discovering if self.retry_rs_at <= now && self.num_solicitations > 0)
     }
 
+    /// Re-enter router discovery without discarding what is already configured.
+    ///
+    /// RFC 4861 §6.3.7 has a host desist from soliciting once it holds a valid
+    /// advertisement, but only "until the next time one of the above events occurs" -- one of
+    /// which is the interface being reinitialized after a temporary failure. Without this,
+    /// `Phase::Maintaining` is terminal: after a link bounce the interface keeps re-installing
+    /// the prefix and router it remembers from before the outage, never asking whether they
+    /// are still real. A host that started while no router was up hits the same wall from
+    /// the other side: once the solicitation budget is spent nothing refills it, so it
+    /// stays in `Discovering` with `num_solicitations` at zero and never asks again.
+    ///
+    /// Prefixes, routes and observed state are kept. Discarding those instead is what
+    /// turning SLAAC off does, see [`Iface::set_slaac`](super::Iface::set_slaac).
+    ///
+    /// `retry_rs_at` is deliberately left alone. On an interface that has been settled a
+    /// while it is already in the past, so the next solicitation goes out at once; when one
+    /// was just sent it is in the future, and honouring it keeps a link that flaps from
+    /// soliciting faster than `RTR_SOLICITATION_INTERVAL`. Assigning `now` here instead
+    /// would let every edge jump that queue.
+    pub(crate) fn restart_discovery(&mut self) {
+        self.phase = Phase::Start;
+        self.num_solicitations = MAX_RTR_SOLICITATIONS;
+    }
+
     /// Update router solicitation tracking state
     ///
     /// Must be called after sending a router solicitation on the interface.

--- a/src/iface/slaac.rs
+++ b/src/iface/slaac.rs
@@ -310,26 +310,11 @@ impl Slaac {
         matches!(self.phase, Phase::Start | Phase::Discovering if self.retry_rs_at <= now && self.num_solicitations > 0)
     }
 
-    /// Re-enter router discovery without discarding what is already configured.
+    /// Solicit again, keeping the prefixes and routes already learned. RFC 4861 §6.3.7.
     ///
-    /// RFC 4861 §6.3.7 has a host desist from soliciting once it holds a valid
-    /// advertisement, but only "until the next time one of the above events occurs" -- one of
-    /// which is the interface being reinitialized after a temporary failure. Without this,
-    /// `Phase::Maintaining` is terminal: after a link bounce the interface keeps re-installing
-    /// the prefix and router it remembers from before the outage, never asking whether they
-    /// are still real. A host that started while no router was up hits the same wall from
-    /// the other side: once the solicitation budget is spent nothing refills it, so it
-    /// stays in `Discovering` with `num_solicitations` at zero and never asks again.
-    ///
-    /// Prefixes, routes and observed state are kept. Discarding those instead is what
-    /// turning SLAAC off does, see [`Iface::set_slaac`](super::Iface::set_slaac).
-    ///
-    /// `retry_rs_at` is deliberately left alone. On an interface that has been settled a
-    /// while it is already in the past, so the next solicitation goes out at once; when one
-    /// was just sent it is in the future, and honouring it keeps a link that flaps from
-    /// soliciting faster than `RTR_SOLICITATION_INTERVAL`. Assigning `now` here instead
-    /// would let every edge jump that queue.
-    pub(crate) fn restart_discovery(&mut self) {
+    /// `retry_rs_at` is left alone so a flapping link cannot solicit faster than
+    /// `RTR_SOLICITATION_INTERVAL`.
+    pub(crate) fn restart(&mut self) {
         self.phase = Phase::Start;
         self.num_solicitations = MAX_RTR_SOLICITATIONS;
     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -843,8 +843,7 @@ impl<'d> Stack<'d> {
             self.inner.fragment_egress(self.ifaces.get_mut(index));
 
             // A link coming back can mean a different network, so re-run both configuration
-            // protocols instead of trusting what was learned before it dropped. Done before
-            // the dispatches below so the first packet leaves in this poll.
+            // protocols instead of trusting what was learned before it dropped.
             #[cfg(any(feature = "dhcpv4", feature = "slaac"))]
             {
                 let iface = self.ifaces.get_mut(index);
@@ -3335,9 +3334,7 @@ pub(crate) mod test {
     }
 
     /// RFC 4861 section 6.3.7 stops solicitation once a router answers, but only "until the
-    /// next time one of the above events occurs" -- one of which is the interface coming back
-    /// after a temporary failure. Without that, a re-association leaves the interface in
-    /// `Maintaining`, re-installing the prefix it remembers from before the outage.
+    /// next time one of the above events occurs".
     #[test]
     #[cfg(feature = "slaac")]
     fn test_slaac_resolicits_after_link_bounce() {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -2702,7 +2702,7 @@ pub(crate) mod test {
     #[cfg(feature = "slaac")]
     use crate::route::RouteOrigin;
     use crate::tcp::State as TcpState;
-    #[cfg(any(feature = "slaac", feature = "dhcpv4"))]
+    #[cfg(feature = "slaac")]
     use crate::test_device::Link;
     use crate::test_device::{Queue, Room, Sent, TestDevice};
     use crate::time::Duration;
@@ -3306,7 +3306,7 @@ pub(crate) mod test {
 
     /// A router advertisement that is not from a link-local source is ignored.
     /// [`test_stack`], also handing out control of the link state the device reports.
-    #[cfg(all(any(feature = "slaac", feature = "dhcpv4"), feature = "medium-ethernet"))]
+    #[cfg(all(feature = "slaac", feature = "medium-ethernet"))]
     fn test_stack_with_link(medium: Medium) -> (Stack<'static>, Queue, Sent, Link) {
         let driver = TestDevice::new(medium);
         let (rx, tx, link) = (driver.rx.clone(), driver.tx.clone(), driver.link.clone());
@@ -3326,39 +3326,12 @@ pub(crate) mod test {
     /// it just after the link comes back. Polling while down is what lets the stack observe
     /// the falling edge.
     #[cfg(all(feature = "slaac", feature = "medium-ethernet"))]
-    #[allow(dead_code)]
     fn bounce_link(stack: &mut Stack<'static>, tx: &Sent, link: &Link, at: i64) {
         link.set(crate::driver::LinkState::Down);
         stack.poll(Instant::from_secs(at));
         tx.borrow_mut().clear();
         link.set(crate::driver::LinkState::Up);
         stack.poll(Instant::from_secs(at + 1));
-    }
-
-    /// The same edge restarts the DHCPv4 client, so it asks again on the network it may
-    /// have moved to instead of waiting out its retry timer. That the restart itself drops
-    /// the lease is covered by `dhcpv4::test::test_restart`.
-    #[test]
-    #[cfg(feature = "dhcpv4")]
-    fn test_dhcpv4_restarts_after_link_bounce() {
-        let (mut stack, _rx, tx, link) = test_stack_with_link(Medium::Ethernet);
-        let iface = IfaceHandle::new(0);
-
-        stack
-            .iface(iface)
-            .set_dhcpv4(Some(crate::iface::dhcpv4::DhcpConfig::default()));
-        stack.poll(Instant::from_secs(0));
-        assert_eq!(tx.borrow().len(), 1, "DISCOVER");
-
-        // The retry timer holds the next one back for now.
-        stack.poll(Instant::from_secs(5));
-        assert_eq!(tx.borrow().len(), 1);
-
-        link.set(crate::driver::LinkState::Down);
-        stack.poll(Instant::from_secs(6));
-        link.set(crate::driver::LinkState::Up);
-        stack.poll(Instant::from_secs(7));
-        assert_eq!(tx.borrow().len(), 2, "the link coming back must restart discovery");
     }
 
     /// RFC 4861 section 6.3.7 stops solicitation once a router answers, but only "until the

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -478,7 +478,7 @@ impl<'d> Stack<'d> {
             dhcpv4: None,
             #[cfg(feature = "slaac")]
             slaac: None,
-            #[cfg(feature = "slaac")]
+            #[cfg(any(feature = "dhcpv4", feature = "slaac"))]
             last_link_state: crate::driver::LinkState::Down,
             #[cfg(feature = "multicast")]
             multicast: crate::multicast::State::new(),
@@ -842,31 +842,34 @@ impl<'d> Stack<'d> {
             #[cfg(any(feature = "ipv4-fragmentation", feature = "sixlowpan-fragmentation"))]
             self.inner.fragment_egress(self.ifaces.get_mut(index));
 
+            // A link coming back can mean a different network, so re-run both configuration
+            // protocols instead of trusting what was learned before it dropped. Done before
+            // the dispatches below so the first packet leaves in this poll.
+            #[cfg(any(feature = "dhcpv4", feature = "slaac"))]
+            {
+                let iface = self.ifaces.get_mut(index);
+                let link_state = iface.driver.link_state();
+                let came_up = link_state != iface.last_link_state && link_state == crate::driver::LinkState::Up;
+                iface.last_link_state = link_state;
+                if came_up {
+                    #[cfg(feature = "dhcpv4")]
+                    iface.dhcpv4_reset(&mut self.inner);
+                    #[cfg(feature = "slaac")]
+                    if let Some(slaac) = iface.slaac.as_mut() {
+                        slaac.restart();
+                    }
+                }
+            }
+
             #[cfg(feature = "dhcpv4")]
             self.ifaces.get_mut(index).dhcpv4_dispatch(&mut self.inner);
 
             #[cfg(feature = "slaac")]
             {
                 let iface = self.ifaces.get_mut(index);
-                // An interface coming back up is one of the events RFC 4861 §6.3.7 solicits
-                // on, so ask the network again rather than trusting what was learned before the
-                // link dropped. Checked before the egress below so the solicitation leaves in
-                // this poll rather than the next one.
-                let link_state = iface.driver.link_state();
-                if link_state != iface.last_link_state {
-                    if link_state == crate::driver::LinkState::Up
-                        && let Some(slaac) = iface.slaac.as_mut()
-                    {
-                        slaac.restart_discovery();
-                    }
-                    iface.last_link_state = link_state;
-                }
-                // Nothing leaves a down link, and `ndisc_rs_egress` counts a solicitation as
-                // sent whether or not the driver took it, so soliciting here would spend the
-                // budget on frames that never went out and leave the interface quiet once the
-                // link returned. A driver that cannot report link state reads as `Up`, which
-                // is the default, so this only ever holds back a driver that said otherwise.
-                if link_state == crate::driver::LinkState::Up {
+                // A solicitation counts as sent even if the driver refuses the frame, so
+                // don't spend the budget on a down link.
+                if iface.last_link_state == crate::driver::LinkState::Up {
                     iface.ndisc_rs_egress(&mut self.inner);
                 }
                 if iface.slaac.as_ref().is_some_and(|s| s.sync_required(timestamp)) {
@@ -2699,7 +2702,7 @@ pub(crate) mod test {
     #[cfg(feature = "slaac")]
     use crate::route::RouteOrigin;
     use crate::tcp::State as TcpState;
-    #[cfg(feature = "slaac")]
+    #[cfg(any(feature = "slaac", feature = "dhcpv4"))]
     use crate::test_device::Link;
     use crate::test_device::{Queue, Room, Sent, TestDevice};
     use crate::time::Duration;
@@ -3303,7 +3306,7 @@ pub(crate) mod test {
 
     /// A router advertisement that is not from a link-local source is ignored.
     /// [`test_stack`], also handing out control of the link state the device reports.
-    #[cfg(all(feature = "slaac", feature = "medium-ethernet"))]
+    #[cfg(all(any(feature = "slaac", feature = "dhcpv4"), feature = "medium-ethernet"))]
     fn test_stack_with_link(medium: Medium) -> (Stack<'static>, Queue, Sent, Link) {
         let driver = TestDevice::new(medium);
         let (rx, tx, link) = (driver.rx.clone(), driver.tx.clone(), driver.link.clone());
@@ -3323,12 +3326,39 @@ pub(crate) mod test {
     /// it just after the link comes back. Polling while down is what lets the stack observe
     /// the falling edge.
     #[cfg(all(feature = "slaac", feature = "medium-ethernet"))]
+    #[allow(dead_code)]
     fn bounce_link(stack: &mut Stack<'static>, tx: &Sent, link: &Link, at: i64) {
         link.set(crate::driver::LinkState::Down);
         stack.poll(Instant::from_secs(at));
         tx.borrow_mut().clear();
         link.set(crate::driver::LinkState::Up);
         stack.poll(Instant::from_secs(at + 1));
+    }
+
+    /// The same edge restarts the DHCPv4 client, so it asks again on the network it may
+    /// have moved to instead of waiting out its retry timer. That the restart itself drops
+    /// the lease is covered by `dhcpv4::test::test_restart`.
+    #[test]
+    #[cfg(feature = "dhcpv4")]
+    fn test_dhcpv4_restarts_after_link_bounce() {
+        let (mut stack, _rx, tx, link) = test_stack_with_link(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+
+        stack
+            .iface(iface)
+            .set_dhcpv4(Some(crate::iface::dhcpv4::DhcpConfig::default()));
+        stack.poll(Instant::from_secs(0));
+        assert_eq!(tx.borrow().len(), 1, "DISCOVER");
+
+        // The retry timer holds the next one back for now.
+        stack.poll(Instant::from_secs(5));
+        assert_eq!(tx.borrow().len(), 1);
+
+        link.set(crate::driver::LinkState::Down);
+        stack.poll(Instant::from_secs(6));
+        link.set(crate::driver::LinkState::Up);
+        stack.poll(Instant::from_secs(7));
+        assert_eq!(tx.borrow().len(), 2, "the link coming back must restart discovery");
     }
 
     /// RFC 4861 section 6.3.7 stops solicitation once a router answers, but only "until the
@@ -3494,11 +3524,10 @@ pub(crate) mod test {
         assert_eq!(route.origin, RouteOrigin::Slaac, "the default route must survive too");
     }
 
-    /// The public escape hatch, for a driver that cannot report link state and so always
-    /// reads as `Up`. Nothing observes an edge here: the caller says when to re-check.
+    /// The manual path, for a driver that cannot report link state.
     #[test]
     #[cfg(feature = "slaac")]
-    fn test_slaac_restart_discovery_by_hand() {
+    fn test_slaac_restart_by_hand() {
         let (mut stack, rx, tx) = test_stack(Medium::Ethernet);
         let iface = IfaceHandle::new(0);
         let router_hw = EthernetAddress([0x02, 0, 0, 0, 0, 0x02]);
@@ -3525,7 +3554,7 @@ pub(crate) mod test {
 
         // The link never changed, so only an explicit call can restart discovery.
         let now = Instant::from_secs(30);
-        stack.iface(iface).restart_slaac_discovery();
+        stack.iface(iface).restart_slaac();
         stack.poll(now);
         assert_eq!(tx.borrow().len(), 1, "an explicit restart must solicit");
         let frame = tx.borrow()[0].clone();
@@ -3540,15 +3569,14 @@ pub(crate) mod test {
         assert!(stack.routes().get_default_ipv6_route().is_some());
     }
 
-    /// Turning SLAAC off leaves nothing to restart, so the call is a no-op rather than a
-    /// panic. Worth pinning: it is reachable from any consumer holding an `Iface`.
+    /// With SLAAC off there is nothing to restart, so the call is a no-op.
     #[test]
     #[cfg(feature = "slaac")]
-    fn test_slaac_restart_discovery_without_slaac_is_a_noop() {
+    fn test_slaac_restart_without_slaac_is_a_noop() {
         let (mut stack, _rx, tx) = test_stack(Medium::Ethernet);
         let iface = IfaceHandle::new(0);
 
-        stack.iface(iface).restart_slaac_discovery();
+        stack.iface(iface).restart_slaac();
         stack.poll(Instant::from_secs(1));
         assert!(tx.borrow().is_empty(), "no SLAAC, nothing to solicit");
     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -478,6 +478,8 @@ impl<'d> Stack<'d> {
             dhcpv4: None,
             #[cfg(feature = "slaac")]
             slaac: None,
+            #[cfg(feature = "slaac")]
+            last_link_state: crate::driver::LinkState::Down,
             #[cfg(feature = "multicast")]
             multicast: crate::multicast::State::new(),
             #[cfg(any(feature = "ipv4-fragmentation", feature = "sixlowpan-fragmentation"))]
@@ -846,7 +848,27 @@ impl<'d> Stack<'d> {
             #[cfg(feature = "slaac")]
             {
                 let iface = self.ifaces.get_mut(index);
-                iface.ndisc_rs_egress(&mut self.inner);
+                // An interface coming back up is one of the events RFC 4861 §6.3.7 solicits
+                // on, so ask the network again rather than trusting what was learned before the
+                // link dropped. Checked before the egress below so the solicitation leaves in
+                // this poll rather than the next one.
+                let link_state = iface.driver.link_state();
+                if link_state != iface.last_link_state {
+                    if link_state == crate::driver::LinkState::Up
+                        && let Some(slaac) = iface.slaac.as_mut()
+                    {
+                        slaac.restart_discovery();
+                    }
+                    iface.last_link_state = link_state;
+                }
+                // Nothing leaves a down link, and `ndisc_rs_egress` counts a solicitation as
+                // sent whether or not the driver took it, so soliciting here would spend the
+                // budget on frames that never went out and leave the interface quiet once the
+                // link returned. A driver that cannot report link state reads as `Up`, which
+                // is the default, so this only ever holds back a driver that said otherwise.
+                if link_state == crate::driver::LinkState::Up {
+                    iface.ndisc_rs_egress(&mut self.inner);
+                }
                 if iface.slaac.as_ref().is_some_and(|s| s.sync_required(timestamp)) {
                     iface.sync_slaac_state(&mut self.inner);
                 }
@@ -2677,6 +2699,8 @@ pub(crate) mod test {
     #[cfg(feature = "slaac")]
     use crate::route::RouteOrigin;
     use crate::tcp::State as TcpState;
+    #[cfg(feature = "slaac")]
+    use crate::test_device::Link;
     use crate::test_device::{Queue, Room, Sent, TestDevice};
     use crate::time::Duration;
     use crate::udp::RecvError as UdpRecvError;
@@ -3278,6 +3302,284 @@ pub(crate) mod test {
     }
 
     /// A router advertisement that is not from a link-local source is ignored.
+    /// [`test_stack`], also handing out control of the link state the device reports.
+    #[cfg(all(feature = "slaac", feature = "medium-ethernet"))]
+    fn test_stack_with_link(medium: Medium) -> (Stack<'static>, Queue, Sent, Link) {
+        let driver = TestDevice::new(medium);
+        let (rx, tx, link) = (driver.rx.clone(), driver.tx.clone(), driver.link.clone());
+        let mut stack = Stack::new(0x1234_5678_dead_beef);
+        let handle = driver.install(&mut stack, HardwareAddress::Ethernet(OUR_HW));
+        stack
+            .iface(handle)
+            .set_ip_addrs([IpCidr::new(OUR_V4.into(), 24), IpCidr::new(OUR_V6.into(), 64)])
+            .unwrap();
+        // Drain the solicited-node multicast reports the new addresses trigger.
+        stack.poll(Instant::ZERO);
+        tx.borrow_mut().clear();
+        (stack, rx, tx, link)
+    }
+
+    /// Take an interface that has settled into `Maintaining` through a link bounce, leaving
+    /// it just after the link comes back. Polling while down is what lets the stack observe
+    /// the falling edge.
+    #[cfg(all(feature = "slaac", feature = "medium-ethernet"))]
+    fn bounce_link(stack: &mut Stack<'static>, tx: &Sent, link: &Link, at: i64) {
+        link.set(crate::driver::LinkState::Down);
+        stack.poll(Instant::from_secs(at));
+        tx.borrow_mut().clear();
+        link.set(crate::driver::LinkState::Up);
+        stack.poll(Instant::from_secs(at + 1));
+    }
+
+    /// RFC 4861 section 6.3.7 stops solicitation once a router answers, but only "until the
+    /// next time one of the above events occurs" -- one of which is the interface coming back
+    /// after a temporary failure. Without that, a re-association leaves the interface in
+    /// `Maintaining`, re-installing the prefix it remembers from before the outage.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_resolicits_after_link_bounce() {
+        let (mut stack, rx, tx, link) = test_stack_with_link(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+        let router_hw = EthernetAddress([0x02, 0, 0, 0, 0, 0x02]);
+        let router_ll = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0xff, 0xfe00, 0x2);
+        let prefix = Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
+
+        stack.iface(iface).set_slaac(Some(SlaacConfig::default()));
+        stack.poll(Instant::from_secs(1));
+
+        // A router answers, so solicitation stops.
+        rx.borrow_mut().push_back(router_advert(
+            router_hw,
+            router_ll,
+            Duration::from_secs(1800),
+            prefix,
+            Duration::from_secs(7200),
+            Duration::from_secs(3600),
+        ));
+        stack.poll(Instant::from_secs(6));
+        tx.borrow_mut().clear();
+        stack.poll(Instant::from_secs(20));
+        assert!(tx.borrow().is_empty(), "a settled interface must not keep soliciting");
+
+        // The link drops and comes back: ask the network again.
+        bounce_link(&mut stack, &tx, &link, 30);
+        assert_eq!(tx.borrow().len(), 1, "the link coming back must trigger a solicitation");
+        let frame = tx.borrow()[0].clone();
+        let (msg_type, _, _, _) = parse_icmpv6_reply(
+            &frame[ETHERNET_HEADER_LEN..],
+            OUR_LINK_LOCAL,
+            IPV6_LINK_LOCAL_ALL_ROUTERS,
+        );
+        assert_eq!(msg_type, Icmpv6Message::RouterSolicit);
+    }
+
+    /// Solicitations are held back while the link is down. `ndisc_rs_egress` counts one as
+    /// sent whether or not the driver accepted the frame, so soliciting into a down link
+    /// would spend the budget on nothing and leave the interface silent once it came back.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_does_not_solicit_on_a_down_link() {
+        let (mut stack, _rx, tx, link) = test_stack_with_link(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+
+        link.set(crate::driver::LinkState::Down);
+        stack.iface(iface).set_slaac(Some(SlaacConfig::default()));
+        for at in [1, 5, 9, 13] {
+            stack.poll(Instant::from_secs(at));
+        }
+        assert!(tx.borrow().is_empty(), "a down link must not be solicited");
+
+        // The budget was not spent while down, so all three still go out once it is back.
+        link.set(crate::driver::LinkState::Up);
+        for at in [20, 24, 28, 32] {
+            stack.poll(Instant::from_secs(at));
+        }
+        assert_eq!(tx.borrow().len(), 3, "the full budget survived the outage");
+        let frame = tx.borrow()[0].clone();
+        let (msg_type, _, _, _) = parse_icmpv6_reply(
+            &frame[ETHERNET_HEADER_LEN..],
+            OUR_LINK_LOCAL,
+            IPV6_LINK_LOCAL_ALL_ROUTERS,
+        );
+        assert_eq!(msg_type, Icmpv6Message::RouterSolicit);
+    }
+
+    /// A link that flaps produces an edge every time it settles, but router solicitations
+    /// still keep to `RTR_SOLICITATION_INTERVAL`: the retry timer decides when the next one
+    /// goes out, not the edge. Otherwise a driver reporting a noisy link -- and xarxa polls a
+    /// level rather than being handed an event -- could solicit on every poll.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_link_flap_keeps_solicitation_spacing() {
+        let (mut stack, rx, tx, link) = test_stack_with_link(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+        let router_hw = EthernetAddress([0x02, 0, 0, 0, 0, 0x02]);
+        let router_ll = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0xff, 0xfe00, 0x2);
+        let prefix = Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
+
+        stack.iface(iface).set_slaac(Some(SlaacConfig::default()));
+        stack.poll(Instant::from_secs(1));
+        rx.borrow_mut().push_back(router_advert(
+            router_hw,
+            router_ll,
+            Duration::from_secs(1800),
+            prefix,
+            Duration::from_secs(7200),
+            Duration::from_secs(3600),
+        ));
+        stack.poll(Instant::from_secs(6));
+
+        // First bounce: settled long enough that the retry timer has passed, so this
+        // solicits at once.
+        bounce_link(&mut stack, &tx, &link, 30);
+        assert_eq!(tx.borrow().len(), 1);
+
+        // Flapping again straight away must not produce another one.
+        link.set(crate::driver::LinkState::Down);
+        stack.poll(Instant::from_secs(32));
+        link.set(crate::driver::LinkState::Up);
+        stack.poll(Instant::from_secs(33));
+        assert_eq!(
+            tx.borrow().len(),
+            1,
+            "a flapping link must not outpace RTR_SOLICITATION_INTERVAL"
+        );
+
+        // Once the interval has passed, the refilled budget is spent normally.
+        stack.poll(Instant::from_secs(36));
+        assert_eq!(
+            tx.borrow().len(),
+            2,
+            "the retry timer, not the edge, releases the next one"
+        );
+    }
+
+    /// Re-soliciting is not the same as tearing SLAAC down: what a router already told us
+    /// stays valid until its lifetime says otherwise, so the addresses and routes have to
+    /// survive the bounce. Discarding them is `set_slaac(None)`, a different operation.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_link_bounce_keeps_configuration() {
+        let (mut stack, rx, tx, link) = test_stack_with_link(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+        let router_hw = EthernetAddress([0x02, 0, 0, 0, 0, 0x02]);
+        let router_ll = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0xff, 0xfe00, 0x2);
+        let prefix = Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
+        let our_addr = IpCidr::new(Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0xff, 0xfe00, 0x1).into(), 64);
+
+        stack.iface(iface).set_slaac(Some(SlaacConfig::default()));
+        rx.borrow_mut().push_back(router_advert(
+            router_hw,
+            router_ll,
+            Duration::from_secs(1800),
+            prefix,
+            Duration::from_secs(7200),
+            Duration::from_secs(3600),
+        ));
+        stack.poll(Instant::from_secs(6));
+        assert!(stack.iface(iface).has_ip_addr(our_addr.address()));
+        assert!(stack.routes().get_default_ipv6_route().is_some());
+
+        bounce_link(&mut stack, &tx, &link, 30);
+
+        assert!(
+            stack
+                .iface(iface)
+                .ip_addrs()
+                .iter()
+                .any(|a| a.cidr == our_addr && a.origin == AddrOrigin::Slaac),
+            "a link bounce must not discard an address whose lifetime is still running"
+        );
+        let route = stack.routes().get_default_ipv6_route().unwrap();
+        assert_eq!(route.origin, RouteOrigin::Slaac, "the default route must survive too");
+    }
+
+    /// The public escape hatch, for a driver that cannot report link state and so always
+    /// reads as `Up`. Nothing observes an edge here: the caller says when to re-check.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_restart_discovery_by_hand() {
+        let (mut stack, rx, tx) = test_stack(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+        let router_hw = EthernetAddress([0x02, 0, 0, 0, 0, 0x02]);
+        let router_ll = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0xff, 0xfe00, 0x2);
+        let prefix = Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
+        let our_addr = IpCidr::new(Ipv6Address::new(0x2001, 0xdb8, 0, 0, 0, 0xff, 0xfe00, 0x1).into(), 64);
+
+        stack.iface(iface).set_slaac(Some(SlaacConfig::default()));
+        // Solicit first: an advertisement only settles the state machine from
+        // `Discovering`, so it has to have asked before the answer arrives.
+        stack.poll(Instant::from_secs(1));
+        rx.borrow_mut().push_back(router_advert(
+            router_hw,
+            router_ll,
+            Duration::from_secs(1800),
+            prefix,
+            Duration::from_secs(7200),
+            Duration::from_secs(3600),
+        ));
+        stack.poll(Instant::from_secs(6));
+        tx.borrow_mut().clear();
+        stack.poll(Instant::from_secs(20));
+        assert!(tx.borrow().is_empty(), "a settled interface must not keep soliciting");
+
+        // The link never changed, so only an explicit call can restart discovery.
+        let now = Instant::from_secs(30);
+        stack.iface(iface).restart_slaac_discovery();
+        stack.poll(now);
+        assert_eq!(tx.borrow().len(), 1, "an explicit restart must solicit");
+        let frame = tx.borrow()[0].clone();
+        let (msg_type, _, _, _) = parse_icmpv6_reply(
+            &frame[ETHERNET_HEADER_LEN..],
+            OUR_LINK_LOCAL,
+            IPV6_LINK_LOCAL_ALL_ROUTERS,
+        );
+        assert_eq!(msg_type, Icmpv6Message::RouterSolicit);
+        // And it re-checks rather than discards, same as the link-up path.
+        assert!(stack.iface(iface).has_ip_addr(our_addr.address()));
+        assert!(stack.routes().get_default_ipv6_route().is_some());
+    }
+
+    /// Turning SLAAC off leaves nothing to restart, so the call is a no-op rather than a
+    /// panic. Worth pinning: it is reachable from any consumer holding an `Iface`.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_restart_discovery_without_slaac_is_a_noop() {
+        let (mut stack, _rx, tx) = test_stack(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+
+        stack.iface(iface).restart_slaac_discovery();
+        stack.poll(Instant::from_secs(1));
+        assert!(tx.borrow().is_empty(), "no SLAAC, nothing to solicit");
+    }
+
+    /// Giving up after the solicitation budget is spent is the other dead end: a host that
+    /// started while no router was up never asked again.
+    #[test]
+    #[cfg(feature = "slaac")]
+    fn test_slaac_resolicits_after_giving_up() {
+        let (mut stack, _rx, tx, link) = test_stack_with_link(Medium::Ethernet);
+        let iface = IfaceHandle::new(0);
+
+        stack.iface(iface).set_slaac(Some(SlaacConfig::default()));
+        // Nothing answers. The three solicitations RFC 4861 allows go out 4s apart, and then
+        // the budget is spent: the interface is left in `Discovering` with nothing to send.
+        for at in [1, 5, 9, 13, 20] {
+            stack.poll(Instant::from_secs(at));
+        }
+        assert_eq!(
+            tx.borrow().len(),
+            3,
+            "MAX_RTR_SOLICITATIONS solicitations, then silence"
+        );
+        tx.borrow_mut().clear();
+        stack.poll(Instant::from_secs(25));
+        assert!(tx.borrow().is_empty(), "the solicitation budget is spent");
+
+        bounce_link(&mut stack, &tx, &link, 30);
+        assert_eq!(tx.borrow().len(), 1, "the link coming back must restart discovery");
+    }
+
     #[test]
     #[cfg(feature = "slaac")]
     fn test_slaac_ignores_invalid_advert() {

--- a/src/test_device.rs
+++ b/src/test_device.rs
@@ -42,6 +42,9 @@ pub type SentMeta = Rc<RefCell<Vec<PacketMeta>>>;
 /// How many more frames the device accepts. `None` is unlimited.
 pub type Room = Rc<Cell<Option<usize>>>;
 
+/// Control over the link state the device reports, shared with the test.
+pub type Link = Rc<Cell<LinkState>>;
+
 /// A mock network device.
 ///
 /// Build one with [`TestDevice::new`] plus the `with_*` setters, then give it to
@@ -68,7 +71,7 @@ pub struct TestDevice {
     /// The hardware address it reports. Set by [`TestDevice::install`].
     pub hardware_addr: HardwareAddress,
     /// The link state it reports.
-    pub link: Rc<Cell<LinkState>>,
+    pub link: Link,
     /// Metadata stamped onto every received packet.
     #[cfg(feature = "packetmeta-id")]
     pub rx_meta: PacketMeta,


### PR DESCRIPTION
`Slaac` never solicits again once a router has answered.
The first advertisement moves the phase to `Maintaining`, and `rs_required` only fires in `Start | Discovering`, so from then on the interface depends entirely on catching the router's periodic multicast RAs.

RFC 4861 section 6.3.7 makes the stop rule conditional, and we only implemented half of it:
> Once the host sends a Router Solicitation, and receives a valid Router Advertisement with a non-zero Router Lifetime, the host MUST desist from sending additional solicitations on that interface, **until the next time one of the above events occurs.**

The main changes -
**`Slaac::restart_discovery()`** re-enters discovery without discarding anything: phase back to `Start`, budget refilled, prefixes and routes untouched.
Setting `Start` also recovers the spent-budget case. 
Discarding what SLAAC configured remains `set_slaac(None)` via `slaac_reset`, which is a different operation and unchanged.

**`Stack::poll`** caches link state per interface and acts on the down -> up edge.
The check sits before `ndisc_rs_egress` so the solicitation leaves in the same poll rather than the next one. `poll_at` needed no change: it already returns `retry_rs_at` for `Start | Discovering` with budget remaining, so the wakeup schedules itself.

**`Iface::restart_slaac_discovery()`** is the manual path, for a driver that cannot report link state, or after some other event meaning the interface may have moved networks (no-op when SLAAC is off).

**Solicitations are held back while the link is down** - `ndisc_rs_egress` ends with:

```rust
inner.transmit_ndisc(self, buf, src_addr, dst_addr);   // returns nothing
self.slaac.as_mut().unwrap().rs_sent(inner.now);
```
`transmit_ndisc` reports nothing, so the budget is spent whether or not the driver took the frame.
Soliciting into a down link burned all three on nothing and left the interface silent once it came back, which would have quietly undercut the restart above.

**Note:**
The budget is still spent on *any* send the driver refuses, not just on a down link.
However, it's a transmit-layer signature change rather than something to fold in this PR.


What do you think?