### PR TITLE
perf(wire): checksum aligned words in unrolled batches

### DIFF
--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -468,37 +468,78 @@ pub mod checksum {
     }
 
     /// Compute an RFC 1071 compliant checksum (without the final complement).
+    #[allow(unsafe_code)]
     pub fn data(data: &[u8]) -> u16 {
-        // We calculate the sum in native-endian before converting to big-endian at the end
-        // see RFC 1071 section 2.(B) for details
+        // This is the same aligned native-endian scheme as lwIP's
+        // LWIP_CHKSUM_ALGORITHM=2. The bulk path reads two Internet-checksum
+        // words with each native u32 load. See RFC 1071 section 2(B).
         let mut accum: u32 = 0;
+        let mut bytes = data;
+        let odd = bytes.as_ptr().addr() & 1 != 0;
+        let mut edge_bytes = [0u8; 2];
 
-        // We manually unroll this hot loop.
-        // When optimizing for size (as is common for microcontrollers) the compiler will not unroll
-        // this. Manually unrolling allows us to do more work per loop tax (compare and branch).
-        // It does not seem to affect the auto-vectorization on bigger machines.
-        let (chunks, mut rem) = data.as_chunks::<4>();
-        for chunk in chunks {
-            let val_0 = u16::from_ne_bytes(chunk[..2].try_into().unwrap());
-            let val_1 = u16::from_ne_bytes(chunk[2..4].try_into().unwrap());
-            accum += val_0 as u32;
-            accum += val_1 as u32;
+        // Align the bulk slice. Byte positions here deliberately describe the
+        // native in-memory u16 representation, as in lwIP's implementation.
+        if odd && !bytes.is_empty() {
+            edge_bytes[1] = bytes[0];
+            bytes = &bytes[1..];
         }
 
-        // Handle 2 bytes of tail, if present.
-        if rem.len() >= 2 {
-            let val = u16::from_ne_bytes(rem[..2].try_into().unwrap());
-            accum += val as u32;
-            rem = &rem[2..];
+        // `bytes` now starts on a u16 boundary. Consume at most one u16 to
+        // reach the native u32 alignment used by the bulk loop.
+        if bytes.len() >= 2 && bytes.as_ptr().addr() & 3 != 0 {
+            // SAFETY: the odd prefix above made the pointer u16-aligned and
+            // the length check proves that two bytes remain.
+            let word = unsafe { bytes.as_ptr().cast::<u16>().read() };
+            accum += word as u32;
+            bytes = &bytes[2..];
         }
 
-        // Add the last remaining odd byte, if any.
-        if let Some(&value) = rem.first() {
-            accum += u16::from_ne_bytes([value, 0]) as u32;
+        // Every u32 bit pattern is valid, and the derived slice stays within
+        // the original allocation.
+        let double_word_count = bytes.len() / 4;
+        let double_words = if double_word_count == 0 {
+            &[]
+        } else {
+            // SAFETY: the optional u16 prefix made the pointer u32-aligned.
+            // `double_word_count * 4 <= bytes.len()`, and every possible
+            // four-byte pattern is a valid u32.
+            unsafe { core::slice::from_raw_parts(bytes.as_ptr().cast::<u32>(), double_word_count) }
+        };
+        let (quad_words, remaining_double_words) = double_words.as_chunks::<4>();
+        let mut accum_0 = accum;
+        let mut accum_1 = 0u32;
+        let mut accum_2 = 0u32;
+        let mut accum_3 = 0u32;
+        for words in quad_words {
+            accum_0 += (words[0] & 0xffff) + (words[0] >> 16);
+            accum_1 += (words[1] & 0xffff) + (words[1] >> 16);
+            accum_2 += (words[2] & 0xffff) + (words[2] >> 16);
+            accum_3 += (words[3] & 0xffff) + (words[3] >> 16);
+        }
+        accum = accum_0 + accum_1 + accum_2 + accum_3;
+        for &double_word in remaining_double_words {
+            accum += (double_word & 0xffff) + (double_word >> 16);
         }
 
-        let collapsed = propagate_carries(accum);
-        u16::to_be(collapsed)
+        let mut tail = &bytes[double_word_count * 4..];
+        if tail.len() >= 2 {
+            // SAFETY: the bulk slice is u32-aligned and two bytes remain.
+            let word = unsafe { tail.as_ptr().cast::<u16>().read() };
+            accum += word as u32;
+            tail = &tail[2..];
+        }
+        if let Some(&last) = tail.first() {
+            edge_bytes[0] = last;
+        }
+        accum += u16::from_ne_bytes(edge_bytes) as u32;
+
+        let mut collapsed = propagate_carries(accum);
+        collapsed = propagate_carries(collapsed as u32);
+        if odd {
+            collapsed = collapsed.swap_bytes();
+        }
+        collapsed.to_be()
     }
 
     /// Combine several RFC 1071 compliant checksums.
@@ -540,6 +581,52 @@ pub mod checksum {
             }
             #[allow(unreachable_patterns)]
             _ => unreachable!(),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::data;
+
+        fn reference(bytes: &[u8]) -> u16 {
+            let mut accum = 0u32;
+            let mut chunks = bytes.chunks_exact(2);
+            for chunk in &mut chunks {
+                accum += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
+            }
+            if let Some(&last) = chunks.remainder().first() {
+                accum += (last as u32) << 8;
+            }
+            let sum = (accum >> 16) + (accum & 0xffff);
+            ((sum >> 16) + (sum & 0xffff)) as u16
+        }
+
+        #[test]
+        fn aligned_native_words_match_reference() {
+            let mut storage = [0u8; 264];
+            for (index, byte) in storage.iter_mut().enumerate() {
+                *byte = (index as u8).wrapping_mul(37).wrapping_add(11);
+            }
+
+            for offset in 0..8 {
+                for length in 0..=255 {
+                    let bytes = &storage[offset..offset + length];
+                    assert_eq!(data(bytes), reference(bytes), "offset={offset} length={length}");
+                }
+            }
+        }
+
+        #[test]
+        fn maximum_ipv4_datagram_matches_reference() {
+            let mut storage = vec![0xffu8; 65_542];
+            for (index, byte) in storage.iter_mut().enumerate() {
+                *byte ^= (index as u8).wrapping_mul(17);
+            }
+
+            for offset in 0..8 {
+                let bytes = &storage[offset..offset + 65_535];
+                assert_eq!(data(bytes), reference(bytes), "offset={offset}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- align the Internet-checksum input and use native `u32` loads for the bulk path
- process 16 bytes per loop with four independent accumulators
- preserve odd-address, odd-length, and native-endian RFC 1071 semantics
- add reference comparisons for offsets 0 through 7, lengths 0 through 255, and the maximum IPv4 datagram length

## Evidence

On a 320 MHz RV32 ESP32-S31 UDP RX workload, the current byte-chunk implementation used 83.51% network-task residence. This implementation used 66.85% while retaining full checksum validation and delivering 112.255 Mbit/s at the measured air ceiling. A same-ELF diagnostic which skipped validation used 56.26%, so checksum validation remains visible but its measured cost is reduced by about 55% relative to the original same-ELF gap.

RV32 release assembly has four aligned `lw` instructions per 16-byte loop iteration. Moving the scalar checksum code to IRAM did not change its cost, consistent with packet loads and arithmetic being the relevant work rather than instruction placement.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace` (565 unit tests plus integration and doctest suites)
- `cargo check -p xarxa --target riscv32imafc-unknown-none-elf --no-default-features --features medium-ethernet,ipv4,udp`
- ESP32-S31 HIL: full software checksum RX 112.255 Mbit/s; three TX ceiling repetitions 103.123-103.237 Mbit/s; five 40/40 Mbit/s bidirectional repetitions 79.980-80.034 Mbit/s combined

The narrowly scoped unsafe reads are preceded by explicit alignment and length checks; all `u16` and `u32` bit patterns are valid.