### PR TITLE
fix(docs): build docs for xarxa and xarxa-driver with async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/xarxa/blob/xarxa-v$VERSION/src/"
 src_base_git = "https://github.com/embassy-rs/xarxa/blob/$COMMIT/src/"
-features = []  # default features
+features = ["async"]  # default features
 target = "x86_64-unknown-linux-gnu"
 
 [features]

--- a/xarxa-driver/Cargo.toml
+++ b/xarxa-driver/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/xarxa/blob/xarxa-driver-v$VERSION/xarxa-driver/src/"
 src_base_git = "https://github.com/embassy-rs/xarxa/blob/$COMMIT/xarxa-driver/src/"
-features = ["packetmeta-timestamp"]
+features = ["packetmeta-timestamp", "async"]
 target = "x86_64-unknown-linux-gnu"
 
 [features]


### PR DESCRIPTION
I think it makes sense to document the async functions too.